### PR TITLE
Add OP-Item database frontend page

### DIFF
--- a/output/db/app.js
+++ b/output/db/app.js
@@ -1,0 +1,1024 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const qs = (selector, scope = document) => scope.querySelector(selector);
+const qsa = (selector, scope = document) => Array.from(scope.querySelectorAll(selector));
+const debounce = (fn, delay = 300) => {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn.apply(null, args), delay);
+  };
+};
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+const env = window.ENV || {};
+let supabaseClient = null;
+
+if (env.PUBLIC_SUPABASE_URL && env.PUBLIC_SUPABASE_ANON_KEY) {
+  supabaseClient = createClient(env.PUBLIC_SUPABASE_URL, env.PUBLIC_SUPABASE_ANON_KEY);
+} else {
+  console.info(
+    "Supabase ENV Variablen fehlen. TODO: PUBLIC_SUPABASE_URL und PUBLIC_SUPABASE_ANON_KEY setzen."
+  );
+}
+
+const state = {
+  user: null,
+  sidebarCollapsed: false,
+  filters: {
+    item_type: "",
+    rarity: ""
+  },
+  searchQuery: "",
+  resultsCount: null,
+  searchLoading: false,
+  enchantments: [],
+  isFilterOpen: false,
+  isProfileOpen: false,
+  modalOpen: false,
+  missingBackendNotified: false
+};
+
+const iconCache = new Map();
+
+const applyIconMarkup = (el, data) => {
+  if (!data) return;
+  ["viewBox", "width", "height"].forEach((attr) => {
+    if (!data.attrs?.[attr]) {
+      el.removeAttribute(attr);
+    }
+  });
+  el.innerHTML = data.markup;
+  Object.entries(data.attrs || {}).forEach(([key, value]) => {
+    if (value) {
+      el.setAttribute(key, value);
+    }
+  });
+};
+let filterOutsideHandler = null;
+let dropdownOutsideHandler = null;
+let profileOutsideHandler = null;
+let modalKeyHandler = null;
+let profileKeyHandler = null;
+let currentSearchToken = 0;
+
+const elements = {
+  sidebar: qs(".sidebar"),
+  sidebarToggle: qs(".sidebar__toggle"),
+  avatarButton: qs("#avatarButton"),
+  avatarDropdown: qs("#avatarDropdown"),
+  dropdownContent: qs("#avatarDropdown .dropdown__content"),
+  searchInput: qs("#searchInput"),
+  searchForm: qs("#searchForm"),
+  filterButton: qs("#filterButton"),
+  filterPopover: qs("#filterPopover"),
+  filterForm: qs("#filterForm"),
+  resetFilters: qs("#resetFilters"),
+  filterClose: qs("[data-close-filter]"),
+  resultInfo: qs("#resultInfo"),
+  addItemButton: qs("#addItemButton"),
+  itemModal: qs("#itemModal"),
+  itemForm: qs("#itemForm"),
+  modalCloseTriggers: qsa("[data-modal-close]"),
+  enchantmentsList: qs("#enchantmentsList"),
+  enchantmentHint: qs("#enchantmentHint"),
+  modalSubmit: qs("#modalSubmit"),
+  toastRegion: qs("#toastRegion"),
+  profilePanel: qs("#profilePanel"),
+  profileEmail: qs("#profileEmail"),
+  profileId: qs("#profileId"),
+  profileClose: qs("[data-close-profile]")
+};
+
+const setResultInfo = () => {
+  if (!elements.resultInfo) return;
+  if (state.searchLoading) {
+    elements.resultInfo.textContent = "Suche läuft…";
+    return;
+  }
+
+  if (state.resultsCount === null) {
+    elements.resultInfo.textContent = "Ergebnisse erscheinen hier…";
+    return;
+  }
+
+  const count = state.resultsCount;
+  if (typeof count === "number") {
+    elements.resultInfo.textContent = count === 0 ? "Keine Ergebnisse gefunden" : `${count} Ergebnisse gefunden`;
+  }
+};
+
+const toast = (message, options = {}) => {
+  const region = elements.toastRegion;
+  if (!region) return;
+  const { duration = 4500 } = options;
+  const toastEl = document.createElement("div");
+  toastEl.className = "toast";
+  toastEl.setAttribute("role", "alert");
+
+  const msg = document.createElement("div");
+  msg.className = "toast__message";
+  msg.textContent = message;
+  toastEl.appendChild(msg);
+
+  const close = document.createElement("button");
+  close.type = "button";
+  close.className = "toast__close";
+  close.setAttribute("aria-label", "Toast schließen");
+  close.textContent = "×";
+  close.addEventListener("click", () => removeToast(toastEl));
+  toastEl.appendChild(close);
+
+  region.appendChild(toastEl);
+  requestAnimationFrame(() => {
+    toastEl.dataset.show = "true";
+  });
+
+  let hideTimeout = setTimeout(() => removeToast(toastEl), duration);
+  const pause = () => {
+    if (!hideTimeout) return;
+    clearTimeout(hideTimeout);
+    hideTimeout = null;
+  };
+  const resume = () => {
+    if (hideTimeout) return;
+    hideTimeout = setTimeout(() => removeToast(toastEl), 1600);
+  };
+
+  toastEl.addEventListener("mouseenter", pause);
+  toastEl.addEventListener("mouseleave", resume);
+};
+
+const removeToast = (toastEl) => {
+  if (!toastEl) return;
+  toastEl.dataset.show = "false";
+  setTimeout(() => toastEl.remove(), 160);
+};
+
+const inlineExternalIcons = async () => {
+  const iconElements = qsa(".icon[data-icon]");
+  await Promise.all(
+    iconElements.map(async (el) => {
+      const name = el.dataset.icon;
+      if (!name) return;
+      el.innerHTML = `<use href="#icon-${name}"></use>`;
+      const cached = iconCache.get(name);
+      if (cached) {
+        applyIconMarkup(el, cached);
+        return;
+      }
+
+      try {
+        const response = await fetch(`../assets/icons/${name}.svg`, { cache: "force-cache" });
+        if (!response.ok) throw new Error("Icon nicht gefunden");
+        const text = await response.text();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(text, "image/svg+xml");
+        const svgNode = doc.querySelector("svg");
+        const iconData = svgNode
+          ? {
+              markup: svgNode.innerHTML,
+              attrs: ["viewBox", "width", "height"].reduce((acc, attr) => {
+                const value = svgNode.getAttribute(attr);
+                if (value) acc[attr] = value;
+                return acc;
+              }, {})
+            }
+          : { markup: text, attrs: {} };
+        iconCache.set(name, iconData);
+        applyIconMarkup(el, iconData);
+      } catch (error) {
+        // fallback already injected
+        const fallback = {
+          markup: `<use href="#icon-${name}"></use>`,
+          attrs: {}
+        };
+        iconCache.set(name, fallback);
+        applyIconMarkup(el, fallback);
+      }
+    })
+  );
+};
+
+const initSidebarState = () => {
+  const stored = localStorage.getItem("sidebarCollapsed");
+  const prefersCollapsed = window.matchMedia("(max-width: 1024px)").matches;
+  state.sidebarCollapsed = stored !== null ? stored === "true" : prefersCollapsed;
+  applySidebarState(true);
+};
+
+const applySidebarState = (isInitial = false) => {
+  if (!elements.sidebar || !elements.sidebarToggle) return;
+  elements.sidebar.dataset.collapsed = String(state.sidebarCollapsed);
+  elements.sidebarToggle.setAttribute("aria-expanded", String(!state.sidebarCollapsed));
+  elements.sidebarToggle.textContent = state.sidebarCollapsed ? "☰" : "×";
+  if (!isInitial) {
+    localStorage.setItem("sidebarCollapsed", String(state.sidebarCollapsed));
+  }
+};
+
+const toggleSidebar = () => {
+  state.sidebarCollapsed = !state.sidebarCollapsed;
+  applySidebarState();
+};
+
+const updateFilterButtonState = () => {
+  if (!elements.filterButton) return;
+  const hasFilter = Boolean(state.filters.item_type || state.filters.rarity);
+  elements.filterButton.dataset.active = hasFilter ? "true" : "false";
+};
+
+const openFilterPopover = () => {
+  if (!elements.filterPopover) return;
+  if (!elements.filterButton) return;
+  if (state.isFilterOpen) return;
+
+  state.isFilterOpen = true;
+  const popover = elements.filterPopover;
+  if (elements.filterForm) {
+    if (elements.filterForm.item_type) {
+      elements.filterForm.item_type.value = state.filters.item_type;
+    }
+    if (elements.filterForm.rarity) {
+      elements.filterForm.rarity.value = state.filters.rarity;
+    }
+  }
+  popover.hidden = false;
+  requestAnimationFrame(() => {
+    const rect = elements.filterButton.getBoundingClientRect();
+    const preferredTop = rect.bottom + 12;
+    const preferredLeft = rect.right - popover.offsetWidth;
+    const top = Math.min(
+      preferredTop,
+      window.innerHeight - popover.offsetHeight - 16
+    );
+    const left = Math.max(16, Math.min(preferredLeft, window.innerWidth - popover.offsetWidth - 16));
+    popover.style.top = `${Math.max(16, top)}px`;
+    popover.style.left = `${left}px`;
+    popover.dataset.open = "true";
+    const focusable = popover.querySelector(FOCUSABLE_SELECTOR);
+    focusable?.focus();
+  });
+
+  elements.filterButton?.setAttribute("aria-expanded", "true");
+
+  filterOutsideHandler = (event) => {
+    if (
+      !elements.filterPopover.contains(event.target) &&
+      !elements.filterButton.contains(event.target)
+    ) {
+      closeFilterPopover();
+    }
+  };
+
+  document.addEventListener("mousedown", filterOutsideHandler, true);
+  document.addEventListener("keydown", handleFilterKeydown);
+};
+
+const handleFilterKeydown = (event) => {
+  if (event.key === "Escape") {
+    event.preventDefault();
+    closeFilterPopover();
+    elements.filterButton?.focus();
+  }
+};
+
+const closeFilterPopover = () => {
+  if (!elements.filterPopover) return;
+  if (!state.isFilterOpen) return;
+  state.isFilterOpen = false;
+  elements.filterButton?.setAttribute("aria-expanded", "false");
+  elements.filterPopover.dataset.open = "false";
+  document.removeEventListener("mousedown", filterOutsideHandler, true);
+  document.removeEventListener("keydown", handleFilterKeydown);
+  filterOutsideHandler = null;
+  setTimeout(() => {
+    if (state.isFilterOpen) return;
+    elements.filterPopover.hidden = true;
+  }, 140);
+};
+
+const openAvatarDropdown = () => {
+  if (!elements.avatarDropdown) return;
+  if (elements.avatarDropdown.dataset.open === "true") return;
+  elements.avatarDropdown.hidden = false;
+  requestAnimationFrame(() => {
+    elements.avatarDropdown.dataset.open = "true";
+  });
+  elements.avatarButton?.setAttribute("aria-expanded", "true");
+
+  dropdownOutsideHandler = (event) => {
+    if (
+      !elements.avatarDropdown.contains(event.target) &&
+      !elements.avatarButton.contains(event.target)
+    ) {
+      closeAvatarDropdown();
+    }
+  };
+
+  document.addEventListener("mousedown", dropdownOutsideHandler, true);
+  document.addEventListener("keydown", handleDropdownKeydown);
+};
+
+const closeAvatarDropdown = () => {
+  if (!elements.avatarDropdown) return;
+  elements.avatarDropdown.dataset.open = "false";
+  elements.avatarButton?.setAttribute("aria-expanded", "false");
+  document.removeEventListener("mousedown", dropdownOutsideHandler, true);
+  document.removeEventListener("keydown", handleDropdownKeydown);
+  dropdownOutsideHandler = null;
+  setTimeout(() => {
+    if (elements.avatarDropdown.dataset.open === "true") return;
+    elements.avatarDropdown.hidden = true;
+  }, 140);
+};
+
+const handleDropdownKeydown = (event) => {
+  if (event.key === "Escape") {
+    event.preventDefault();
+    closeAvatarDropdown();
+    elements.avatarButton?.focus();
+  }
+};
+
+const openProfilePanel = () => {
+  if (!elements.profilePanel) return;
+  if (state.isProfileOpen) return;
+  state.isProfileOpen = true;
+  elements.profilePanel.hidden = false;
+  requestAnimationFrame(() => {
+    elements.profilePanel.dataset.open = "true";
+    elements.profilePanel.querySelector("button")?.focus();
+  });
+
+  profileOutsideHandler = (event) => {
+    if (
+      !elements.profilePanel.contains(event.target) &&
+      !elements.avatarDropdown.contains(event.target)
+    ) {
+      closeProfilePanel();
+    }
+  };
+
+  profileKeyHandler = (event) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeProfilePanel();
+      elements.avatarButton?.focus();
+    }
+  };
+
+  document.addEventListener("mousedown", profileOutsideHandler, true);
+  document.addEventListener("keydown", profileKeyHandler);
+};
+
+const closeProfilePanel = () => {
+  if (!elements.profilePanel || !state.isProfileOpen) return;
+  state.isProfileOpen = false;
+  elements.profilePanel.dataset.open = "false";
+  document.removeEventListener("mousedown", profileOutsideHandler, true);
+  document.removeEventListener("keydown", profileKeyHandler);
+  profileOutsideHandler = null;
+  profileKeyHandler = null;
+  setTimeout(() => {
+    if (state.isProfileOpen) return;
+    elements.profilePanel.hidden = true;
+  }, 140);
+};
+
+const openItemModal = async () => {
+  if (!state.user) {
+    openAvatarDropdown();
+    toast("Bitte per Discord anmelden", { duration: 5000 });
+    return;
+  }
+
+  if (!supabaseClient) {
+    toast("Supabase Konfiguration fehlt", { duration: 5000 });
+    return;
+  }
+
+  await ensureEnchantments();
+  renderEnchantments();
+
+  if (!elements.itemModal) return;
+  if (state.modalOpen) return;
+  state.modalOpen = true;
+  elements.itemModal.hidden = false;
+  requestAnimationFrame(() => {
+    elements.itemModal.dataset.open = "true";
+    trapFocus(elements.itemModal);
+    const firstFocusable = getFocusableElements(elements.itemModal)[0];
+    firstFocusable?.focus();
+  });
+};
+
+const closeItemModal = () => {
+  if (!elements.itemModal || !state.modalOpen) return;
+  state.modalOpen = false;
+  elements.itemModal.dataset.open = "false";
+  releaseFocus();
+  elements.itemForm?.reset();
+  setTimeout(() => {
+    if (state.modalOpen) return;
+    elements.itemModal.hidden = true;
+  }, 140);
+};
+
+const getFocusableElements = (container) => {
+  return qsa(FOCUSABLE_SELECTOR, container).filter((el) => {
+    if (el.hasAttribute("disabled")) return false;
+    if (el.getAttribute("aria-hidden") === "true") return false;
+    const style = window.getComputedStyle(el);
+    if (style.display === "none" || style.visibility === "hidden") return false;
+    if (el.offsetParent === null && style.position !== "fixed") return false;
+    return true;
+  });
+};
+
+let focusTrap = null;
+
+const trapFocus = (container) => {
+  releaseFocus();
+  const focusable = getFocusableElements(container);
+  const previouslyFocused = document.activeElement;
+  focusTrap = {
+    container,
+    focusable,
+    previouslyFocused
+  };
+
+  modalKeyHandler = (event) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeItemModal();
+      return;
+    }
+
+    if (event.key === "Tab" && focusTrap?.focusable.length) {
+      const { focusable } = focusTrap;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  document.addEventListener("keydown", modalKeyHandler);
+};
+
+const releaseFocus = () => {
+  if (!focusTrap) return;
+  document.removeEventListener("keydown", modalKeyHandler);
+  focusTrap.previouslyFocused?.focus?.();
+  focusTrap = null;
+  modalKeyHandler = null;
+};
+
+const ensureEnchantments = async () => {
+  if (!elements.enchantmentHint) return;
+  if (!supabaseClient) {
+    elements.enchantmentHint.textContent = "Keine Verbindung zur Datenbank";
+    state.enchantments = [];
+    return;
+  }
+
+  if (state.enchantments.length) {
+    elements.enchantmentHint.textContent =
+      "Wähle Verzauberungen aus und gib ein Level an.";
+    return;
+  }
+
+  elements.enchantmentHint.textContent = "Lade Verzauberungen…";
+
+  try {
+    const { data, error } = await supabaseClient
+      .from("enchantments")
+      .select("id, name, max_level")
+      .order("name", { ascending: true });
+    if (error) throw error;
+    state.enchantments = data ?? [];
+    elements.enchantmentHint.textContent = state.enchantments.length
+      ? "Wähle Verzauberungen aus und gib ein Level an."
+      : "Keine Verzauberungen vorhanden.";
+  } catch (error) {
+    console.error(error);
+    toast("Verzauberungen konnten nicht geladen werden", { duration: 5000 });
+    elements.enchantmentHint.textContent = "Fehler beim Laden";
+  }
+};
+
+const renderEnchantments = () => {
+  if (!elements.enchantmentsList) return;
+  elements.enchantmentsList.innerHTML = "";
+  if (!state.enchantments.length) return;
+
+  state.enchantments.forEach((ench) => {
+    const option = document.createElement("div");
+    option.className = "enchantment-option";
+    const checkboxId = `enchantment-${ench.id}`;
+    option.innerHTML = `
+      <label for="${checkboxId}">
+        <input type="checkbox" id="${checkboxId}" name="enchantments" value="${ench.id}" />
+        <span>${ench.name}</span>
+        <span class="enchantment-option__max">max ${ench.max_level ?? 1}</span>
+      </label>
+      <div class="enchantment-option__level" data-level-container hidden>
+        <label>
+          Level
+          <input type="number" name="enchantment-level-${ench.id}" min="1" max="${ench.max_level ?? 1}" value="1" />
+        </label>
+      </div>
+    `;
+
+    const checkbox = option.querySelector("input[type='checkbox']");
+    const levelContainer = option.querySelector("[data-level-container]");
+    const levelInput = option.querySelector("input[type='number']");
+    checkbox.addEventListener("change", () => {
+      if (checkbox.checked) {
+        option.classList.add("is-active");
+        levelContainer.hidden = false;
+        levelInput.focus();
+      } else {
+        option.classList.remove("is-active");
+        levelContainer.hidden = true;
+      }
+    });
+
+    elements.enchantmentsList.appendChild(option);
+  });
+  resetEnchantmentLevels();
+};
+
+function resetEnchantmentLevels() {
+  if (!elements.enchantmentsList) return;
+  qsa(".enchantment-option", elements.enchantmentsList).forEach((option) => {
+    option.classList.remove("is-active");
+    const levelContainer = option.querySelector("[data-level-container]");
+    if (levelContainer) {
+      levelContainer.hidden = true;
+    }
+  });
+}
+
+const performSearch = async () => {
+  const token = ++currentSearchToken;
+  state.searchLoading = true;
+  setResultInfo();
+
+  const query = state.searchQuery.trim();
+  if (!query && !state.filters.item_type && !state.filters.rarity) {
+    if (token === currentSearchToken) {
+      state.searchLoading = false;
+      state.resultsCount = null;
+      setResultInfo();
+    }
+    return;
+  }
+
+  try {
+    const count = await executeSearch({ query, filters: state.filters });
+    if (token === currentSearchToken) {
+      state.resultsCount = typeof count === "number" ? count : null;
+    }
+  } catch (error) {
+    console.error(error);
+    if (token === currentSearchToken) {
+      toast("Suche fehlgeschlagen", { duration: 5000 });
+      state.resultsCount = null;
+    }
+  } finally {
+    if (token === currentSearchToken) {
+      state.searchLoading = false;
+      setResultInfo();
+    }
+  }
+};
+
+const executeSearch = async ({ query, filters }) => {
+  const params = new URLSearchParams();
+  if (query) params.set("q", query);
+  if (filters.item_type) params.set("type", filters.item_type);
+  if (filters.rarity) params.set("rarity", filters.rarity);
+
+  if (env.API_BASE) {
+    const base = env.API_BASE.replace(/\/$/, "");
+    const url = `${base}/search?${params.toString()}`;
+    const response = await fetch(url, {
+      headers: { Accept: "application/json" },
+      credentials: "include"
+    });
+    if (!response.ok) {
+      throw new Error("API-Antwort fehlgeschlagen");
+    }
+    const payload = await response.json();
+    if (typeof payload.count === "number") return payload.count;
+    if (Array.isArray(payload.results)) return payload.results.length;
+    return null;
+  }
+
+  if (!supabaseClient) {
+    if (!state.missingBackendNotified) {
+      toast("Keine API oder Supabase konfiguriert", { duration: 5000 });
+      state.missingBackendNotified = true;
+    }
+    return null;
+  }
+
+  let builder = supabaseClient.from("items").select("id", { count: "exact", head: true });
+  if (query) {
+    builder = builder.ilike("name", `%${query}%`);
+  }
+  if (filters.item_type) {
+    builder = builder.eq("item_type", filters.item_type);
+  }
+  if (filters.rarity) {
+    builder = builder.eq("rarity", filters.rarity);
+  }
+
+  const { count, error } = await builder;
+  if (error) throw error;
+  return count ?? 0;
+};
+
+const handleAvatarAction = async (action) => {
+  switch (action) {
+    case "login":
+      if (!supabaseClient) {
+        toast("Supabase Konfiguration fehlt", { duration: 5000 });
+        return;
+      }
+      try {
+        const redirectTo = `${window.location.origin}${window.location.pathname}`;
+        await supabaseClient.auth.signInWithOAuth({
+          provider: "discord",
+          options: { redirectTo }
+        });
+      } catch (error) {
+        console.error(error);
+        toast("Anmeldung fehlgeschlagen", { duration: 5000 });
+      }
+      break;
+    case "profile":
+      updateProfilePanel();
+      openProfilePanel();
+      break;
+    case "logout":
+      if (!supabaseClient) {
+        toast("Supabase Konfiguration fehlt", { duration: 5000 });
+        return;
+      }
+      try {
+        await supabaseClient.auth.signOut();
+        toast("Erfolgreich abgemeldet", { duration: 4000 });
+      } catch (error) {
+        console.error(error);
+        toast("Abmelden fehlgeschlagen", { duration: 5000 });
+      }
+      break;
+    default:
+      break;
+  }
+};
+
+const updateProfilePanel = () => {
+  if (!state.user || !elements.profileEmail || !elements.profileId) return;
+  elements.profileEmail.textContent = state.user.email ?? "-";
+  elements.profileId.textContent = state.user.id ?? "-";
+};
+
+const handleItemSubmit = async (event) => {
+  event.preventDefault();
+  if (!supabaseClient) {
+    toast("Supabase Konfiguration fehlt", { duration: 5000 });
+    return;
+  }
+  if (!state.user) {
+    toast("Bitte per Discord anmelden", { duration: 5000 });
+    openAvatarDropdown();
+    return;
+  }
+
+  const formData = new FormData(elements.itemForm);
+  const name = (formData.get("name") || "").toString().trim();
+  const itemType = formData.get("item_type");
+  const rarity = formData.get("rarity");
+  const starLevelValue = formData.get("star_level");
+  const priceValue = formData.get("price");
+  const imageUrl = (formData.get("image_url") || "").toString().trim();
+
+  if (!name) {
+    toast("Name ist erforderlich", { duration: 4000 });
+    return;
+  }
+
+  if (!itemType) {
+    toast("Item-Art auswählen", { duration: 4000 });
+    return;
+  }
+
+  if (!rarity) {
+    toast("Seltenheit auswählen", { duration: 4000 });
+    return;
+  }
+
+  const starLevel = Number.parseInt(starLevelValue, 10) || 0;
+  if (starLevel < 0) {
+    toast("Stern-Level muss ≥ 0 sein", { duration: 4000 });
+    return;
+  }
+
+  const price = priceValue ? Number.parseFloat(priceValue) : null;
+  if (price !== null && price < 0) {
+    toast("Preis muss ≥ 0 sein", { duration: 4000 });
+    return;
+  }
+
+  const selectedEnchantments = formData.getAll("enchantments");
+  const enchantmentPayload = [];
+
+  for (const enchantmentId of selectedEnchantments) {
+    const def = state.enchantments.find((ench) => String(ench.id) === String(enchantmentId));
+    const levelRaw = formData.get(`enchantment-level-${enchantmentId}`);
+    const level = Number.parseInt(levelRaw, 10);
+    if (!def) continue;
+    const maxLevel = def.max_level ?? 1;
+    if (!level || level < 1 || level > maxLevel) {
+      toast(`Level für ${def.name} muss zwischen 1 und ${maxLevel} liegen`, { duration: 5000 });
+      return;
+    }
+    enchantmentPayload.push({
+      enchantment_id: def.id,
+      level
+    });
+  }
+
+  elements.modalSubmit.disabled = true;
+  const originalText = elements.modalSubmit.textContent;
+  elements.modalSubmit.textContent = "Speichern…";
+
+  try {
+    const { data, error } = await supabaseClient
+      .from("items")
+      .insert([
+        {
+          name,
+          item_type: itemType,
+          rarity,
+          star_level: starLevel,
+          price,
+          image_url: imageUrl || null,
+          creator: state.user.id
+        }
+      ])
+      .select("id")
+      .single();
+    if (error) throw error;
+
+    if (enchantmentPayload.length) {
+      const rows = enchantmentPayload.map((row) => ({
+        item_id: data.id,
+        enchantment_id: row.enchantment_id,
+        level: row.level
+      }));
+      const { error: linkError } = await supabaseClient
+        .from("item_enchantments")
+        .insert(rows);
+      if (linkError) throw linkError;
+    }
+
+    toast("Item gespeichert", { duration: 4000 });
+    closeItemModal();
+    elements.itemForm.reset();
+    performSearch();
+  } catch (error) {
+    console.error(error);
+    toast(error.message || "Speichern fehlgeschlagen", { duration: 5000 });
+  } finally {
+    elements.modalSubmit.disabled = false;
+    elements.modalSubmit.textContent = originalText;
+  }
+};
+
+const renderAvatar = () => {
+  if (!elements.avatarButton) return;
+  const inner = elements.avatarButton.querySelector(".avatar-button__inner");
+  if (!inner) return;
+  inner.innerHTML = "";
+  inner.classList.remove("avatar-button__inner--image", "avatar-button__inner--initials");
+  elements.avatarButton.classList.remove("avatar-button--image");
+
+  if (!state.user) {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.classList.add("icon");
+    svg.dataset.icon = "user";
+    inner.appendChild(svg);
+    elements.avatarButton.setAttribute("title", "Gastkonto");
+    inlineExternalIcons();
+    return;
+  }
+
+  const metadata = state.user.user_metadata || {};
+  const avatarUrl = metadata.avatar_url || metadata.picture || metadata.avatar;
+  const displayName = metadata.full_name || metadata.name || metadata.preferred_username || state.user.email || "User";
+
+  if (avatarUrl) {
+    const img = document.createElement("img");
+    img.src = avatarUrl;
+    img.alt = "";
+    img.className = "avatar-button__image";
+    inner.appendChild(img);
+    inner.classList.add("avatar-button__inner--image");
+    elements.avatarButton.classList.add("avatar-button--image");
+  } else {
+    const initials = displayName
+      .split(/\s+/)
+      .map((part) => part[0])
+      .filter(Boolean)
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+    inner.textContent = initials || "U";
+    inner.classList.add("avatar-button__inner--initials");
+  }
+
+  elements.avatarButton.setAttribute("title", displayName);
+};
+
+const escapeHTML = (value) => {
+  const div = document.createElement("div");
+  div.textContent = value;
+  return div.innerHTML;
+};
+
+const renderAvatarDropdown = () => {
+  if (!elements.dropdownContent) return;
+  let html = "";
+
+  if (!state.user) {
+    html = `
+      <button class="dropdown__item" type="button" data-action="login" role="menuitem">
+        Mit Discord anmelden
+      </button>
+    `;
+  } else {
+    const metadata = state.user.user_metadata || {};
+    const displayName = metadata.full_name || metadata.name || metadata.preferred_username || state.user.email || "Nutzer";
+    const email = state.user.email ? `<span class="dropdown__user-meta">${escapeHTML(state.user.email)}</span>` : "";
+    html = `
+      <div class="dropdown__user" role="presentation">
+        <span class="dropdown__user-name">${escapeHTML(displayName)}</span>
+        ${email}
+      </div>
+      <div class="dropdown__separator" role="none"></div>
+      <button class="dropdown__item" type="button" data-action="profile" role="menuitem">Profil</button>
+      <button class="dropdown__item" type="button" data-action="logout" role="menuitem">Abmelden</button>
+    `;
+  }
+
+  elements.dropdownContent.innerHTML = html;
+};
+
+const attachEventListeners = () => {
+  elements.sidebarToggle?.addEventListener("click", toggleSidebar);
+
+  elements.avatarButton?.addEventListener("click", () => {
+    if (elements.avatarDropdown.dataset.open === "true") {
+      closeAvatarDropdown();
+    } else {
+      renderAvatarDropdown();
+      openAvatarDropdown();
+    }
+  });
+
+  elements.avatarDropdown?.addEventListener("click", (event) => {
+    const target = event.target.closest("[data-action]");
+    if (!target) return;
+    const action = target.dataset.action;
+    handleAvatarAction(action);
+    closeAvatarDropdown();
+  });
+
+  elements.searchInput?.addEventListener("input", (event) => {
+    state.searchQuery = event.target.value;
+    debouncedSearch();
+  });
+
+  elements.searchForm?.addEventListener("submit", (event) => {
+    event.preventDefault();
+    state.searchQuery = elements.searchInput?.value || "";
+    performSearch();
+  });
+
+  elements.filterButton?.addEventListener("click", () => {
+    if (state.isFilterOpen) {
+      closeFilterPopover();
+    } else {
+      openFilterPopover();
+    }
+  });
+
+  elements.filterForm?.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(elements.filterForm);
+    state.filters.item_type = formData.get("item_type") || "";
+    state.filters.rarity = formData.get("rarity") || "";
+    updateFilterButtonState();
+    closeFilterPopover();
+    performSearch();
+  });
+
+  elements.resetFilters?.addEventListener("click", () => {
+    if (!elements.filterForm) return;
+    elements.filterForm.reset();
+    state.filters.item_type = "";
+    state.filters.rarity = "";
+    updateFilterButtonState();
+    performSearch();
+  });
+
+  elements.filterClose?.addEventListener("click", () => {
+    closeFilterPopover();
+    elements.filterButton?.focus();
+  });
+
+  elements.addItemButton?.addEventListener("click", () => {
+    openItemModal();
+  });
+
+  elements.modalCloseTriggers.forEach((trigger) => {
+    trigger.addEventListener("click", () => {
+      closeItemModal();
+    });
+  });
+
+  elements.itemForm?.addEventListener("submit", handleItemSubmit);
+  elements.itemForm?.addEventListener("reset", resetEnchantmentLevels);
+
+  elements.profileClose?.addEventListener("click", () => {
+    closeProfilePanel();
+    elements.avatarButton?.focus();
+  });
+
+  window.addEventListener("resize", () => {
+    if (state.isFilterOpen) {
+      closeFilterPopover();
+    }
+  });
+};
+
+const debouncedSearch = debounce(() => {
+  state.searchQuery = elements.searchInput?.value || "";
+  performSearch();
+}, 300);
+
+const initAuth = async () => {
+  if (!supabaseClient) {
+    renderAvatar();
+    renderAvatarDropdown();
+    return;
+  }
+
+  try {
+    const {
+      data: { session }
+    } = await supabaseClient.auth.getSession();
+    state.user = session?.user ?? null;
+    renderAvatar();
+    renderAvatarDropdown();
+  } catch (error) {
+    console.error(error);
+    toast("Konnte Auth-Status nicht laden", { duration: 5000 });
+  }
+
+  supabaseClient.auth.onAuthStateChange((_event, session) => {
+    state.user = session?.user ?? null;
+    renderAvatar();
+    renderAvatarDropdown();
+    if (!state.user) {
+      closeProfilePanel();
+    }
+  });
+};
+
+const init = () => {
+  inlineExternalIcons();
+  initSidebarState();
+  updateFilterButtonState();
+  setResultInfo();
+  attachEventListeners();
+  initAuth();
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", init);
+} else {
+  init();
+}

--- a/output/db/index.html
+++ b/output/db/index.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OP-Item Datenbank</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <svg aria-hidden="true" style="position: absolute; width: 0; height: 0; overflow: hidden">
+      <symbol id="icon-search" viewBox="0 0 24 24">
+        <path
+          fill="currentColor"
+          d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.71.71l.27.28v.79l5 5a1 1 0 0 0 1.41-1.41zm-6 0a4.5 4.5 0 1 1 4.5-4.5 4.5 4.5 0 0 1-4.5 4.5"
+        />
+      </symbol>
+      <symbol id="icon-filter" viewBox="0 0 24 24">
+        <path
+          fill="currentColor"
+          d="M3 5a1 1 0 0 1 1-1h16a1 1 0 0 1 .8 1.6l-5.2 6.93V19a1 1 0 0 1-.55.89l-4 2A1 1 0 0 1 9 21v-7.47L3.2 5.6A1 1 0 0 1 3 5"
+        />
+      </symbol>
+      <symbol id="icon-user" viewBox="0 0 24 24">
+        <path
+          fill="currentColor"
+          d="M12 2a6 6 0 1 1 0 12 6 6 0 0 1 0-12m0 14c4.2 0 8 1.89 8 4.2V22H4v-1.8C4 17.89 7.8 16 12 16"
+        />
+      </symbol>
+    </svg>
+
+    <div class="app-shell">
+      <aside class="sidebar" data-collapsed="false">
+        <div class="sidebar__header">
+          <button
+            class="sidebar__toggle"
+            type="button"
+            aria-label="Navigation ein-/ausklappen"
+            aria-expanded="true"
+          >
+            ☰
+          </button>
+          <span class="sidebar__title">OP&nbsp;Tools</span>
+        </div>
+        <nav class="sidebar__nav" aria-label="Hauptnavigation">
+          <a class="sidebar__link" href="#">
+            <span class="sidebar__icon" aria-hidden="true">🏠</span>
+            <span class="sidebar__text">Startseite</span>
+          </a>
+          <a class="sidebar__link is-active" href="#" aria-current="page">
+            <span class="sidebar__icon" aria-hidden="true">📦</span>
+            <span class="sidebar__text">OP-Item Datenbank</span>
+          </a>
+        </nav>
+      </aside>
+
+      <div class="main-area">
+        <header class="topbar">
+          <div class="topbar__spacer" aria-hidden="true"></div>
+          <div class="topbar__actions">
+            <button
+              class="avatar-button"
+              type="button"
+              id="avatarButton"
+              aria-haspopup="true"
+              aria-expanded="false"
+              aria-label="Benutzerkonto"
+            >
+              <span class="avatar-button__inner" aria-hidden="true">
+                <svg class="icon" data-icon="user" focusable="false" aria-hidden="true"></svg>
+              </span>
+            </button>
+          </div>
+          <div class="dropdown" id="avatarDropdown" role="menu" aria-labelledby="avatarButton" hidden>
+            <div class="dropdown__content" role="none">
+              <button class="dropdown__item" type="button" data-action="login" role="menuitem">
+                Mit Discord anmelden
+              </button>
+            </div>
+          </div>
+        </header>
+
+        <main class="content" role="main">
+          <section class="search-panel" aria-label="Item Suche">
+            <form class="search-form" id="searchForm" role="search">
+              <label class="visually-hidden" for="searchInput">Item suchen</label>
+              <div class="search-form__field">
+                <span class="search-form__icon" aria-hidden="true">
+                  <svg class="icon" data-icon="search" focusable="false"></svg>
+                </span>
+                <input
+                  id="searchInput"
+                  name="search"
+                  type="search"
+                  placeholder="Item suchen…"
+                  autocomplete="off"
+                  aria-label="Item suchen"
+                />
+                <button
+                  class="search-form__filter"
+                  type="button"
+                  id="filterButton"
+                  aria-haspopup="dialog"
+                  aria-expanded="false"
+                  aria-controls="filterPopover"
+                >
+                  <svg class="icon" data-icon="filter" focusable="false"></svg>
+                  <span class="visually-hidden">Filter öffnen</span>
+                </button>
+              </div>
+            </form>
+            <div class="search-panel__actions">
+              <button class="button button--primary" id="addItemButton" type="button">
+                Item hinzufügen
+              </button>
+              <p class="search-panel__result" id="resultInfo" aria-live="polite"></p>
+            </div>
+          </section>
+        </main>
+      </div>
+    </div>
+
+    <div class="popover" id="filterPopover" role="dialog" aria-modal="false" hidden>
+      <form id="filterForm" class="popover__form">
+        <header class="popover__header">
+          <h2>Filter</h2>
+          <button class="popover__close" type="button" data-close-filter aria-label="Filter schließen">×</button>
+        </header>
+        <div class="popover__body">
+          <label class="field">
+            <span class="field__label">Item-Art</span>
+            <select name="item_type" aria-label="Item-Art auswählen">
+              <option value="">Alle</option>
+              <option value="sword">Sword</option>
+              <option value="axe">Axe</option>
+              <option value="bow">Bow</option>
+              <option value="armor">Armor</option>
+              <option value="tool">Tool</option>
+              <option value="trinket">Trinket</option>
+            </select>
+          </label>
+          <label class="field">
+            <span class="field__label">Seltenheit</span>
+            <select name="rarity" aria-label="Seltenheit auswählen">
+              <option value="">Alle</option>
+              <option value="common">Common</option>
+              <option value="rare">Rare</option>
+              <option value="epic">Epic</option>
+              <option value="legendary">Legendary</option>
+              <option value="mythic">Mythic</option>
+            </select>
+          </label>
+        </div>
+        <footer class="popover__footer">
+          <button class="button button--ghost" type="button" id="resetFilters">Zurücksetzen</button>
+          <button class="button button--primary" type="submit">Übernehmen</button>
+        </footer>
+      </form>
+    </div>
+
+    <div class="modal" id="itemModal" role="dialog" aria-modal="true" aria-labelledby="itemModalTitle" hidden>
+      <div class="modal__backdrop" data-modal-close></div>
+      <div class="modal__dialog" role="document">
+        <header class="modal__header">
+          <h2 id="itemModalTitle">Item hinzufügen</h2>
+          <button class="modal__close" type="button" aria-label="Modal schließen" data-modal-close>
+            ×
+          </button>
+        </header>
+        <form class="modal__form" id="itemForm">
+          <div class="form-grid">
+            <label class="field">
+              <span class="field__label">Name</span>
+              <input type="text" name="name" required autocomplete="off" />
+            </label>
+            <label class="field">
+              <span class="field__label">Item-Art</span>
+              <select name="item_type" required>
+                <option value="" disabled selected hidden>Bitte wählen</option>
+                <option value="sword">Sword</option>
+                <option value="axe">Axe</option>
+                <option value="bow">Bow</option>
+                <option value="armor">Armor</option>
+                <option value="tool">Tool</option>
+                <option value="trinket">Trinket</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="field__label">Seltenheit</span>
+              <select name="rarity" required>
+                <option value="" disabled selected hidden>Bitte wählen</option>
+                <option value="common">Common</option>
+                <option value="uncommon">Uncommon</option>
+                <option value="rare">Rare</option>
+                <option value="epic">Epic</option>
+                <option value="legendary">Legendary</option>
+                <option value="mythic">Mythic</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="field__label">Stern-Level</span>
+              <input type="number" name="star_level" min="0" step="1" value="0" />
+            </label>
+            <label class="field">
+              <span class="field__label">Preis</span>
+              <input type="number" name="price" min="0" step="0.01" placeholder="Optional" />
+            </label>
+            <label class="field">
+              <span class="field__label">Bild-URL</span>
+              <input type="url" name="image_url" placeholder="https://…" />
+            </label>
+          </div>
+          <fieldset class="field field--enchantments">
+            <legend class="field__label">Verzauberungen</legend>
+            <p class="field__hint" id="enchantmentHint">
+              Lade Verzauberungen…
+            </p>
+            <div class="enchantments" id="enchantmentsList" role="group" aria-labelledby="enchantmentHint"></div>
+          </fieldset>
+          <div class="modal__actions">
+            <button class="button button--ghost" type="button" data-modal-close>Abbrechen</button>
+            <button class="button button--primary" type="submit" id="modalSubmit">Speichern</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div class="profile-panel" id="profilePanel" role="dialog" aria-modal="false" hidden>
+      <div class="profile-panel__content">
+        <h3>Profil</h3>
+        <dl>
+          <div>
+            <dt>E-Mail</dt>
+            <dd id="profileEmail">-</dd>
+          </div>
+          <div>
+            <dt>User-ID</dt>
+            <dd id="profileId">-</dd>
+          </div>
+        </dl>
+        <button class="button button--ghost" type="button" data-close-profile>Schließen</button>
+      </div>
+    </div>
+
+    <div class="toast-region" id="toastRegion" aria-live="polite" aria-atomic="false"></div>
+
+    <script>
+      // TODO: Hier PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY und optional API_BASE eintragen.
+      window.ENV = window.ENV || {
+        PUBLIC_SUPABASE_URL: "",
+        PUBLIC_SUPABASE_ANON_KEY: "",
+        API_BASE: ""
+      };
+    </script>
+    <script type="module" src="./app.js"></script>
+
+    <!--
+      README-Snippet:
+      - Lokales Preview: `wrangler pages dev ./output`
+      - Vor dem Deploy `PUBLIC_SUPABASE_URL` und `PUBLIC_SUPABASE_ANON_KEY` in window.ENV setzen.
+      - Discord OAuth Redirect-URL in Supabase/Discord auf `https://<deine-domain>/db/` (bzw. lokal `http://127.0.0.1:8788/db/`) konfigurieren.
+    -->
+  </body>
+</html>

--- a/output/db/style.css
+++ b/output/db/style.css
@@ -1,0 +1,931 @@
+/* Modern Normalize (lokal) */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html {
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  font-size: 16px;
+  color: #eaf2ff;
+  background-color: #05080d;
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+main {
+  display: block;
+}
+
+a {
+  background-color: transparent;
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  border-style: none;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+button {
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+:root {
+  color-scheme: dark;
+  --color-bg: rgba(11, 15, 20, 0.8);
+  --color-bg-strong: rgba(20, 24, 30, 0.65);
+  --color-bg-highlight: rgba(28, 34, 45, 0.75);
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-text: #eaf2ff;
+  --color-text-muted: rgba(234, 242, 255, 0.75);
+  --color-primary: #5aa1ff;
+  --color-primary-hover: #78b4ff;
+  --focus-ring: 0 0 0 2px rgba(90, 161, 255, 0.3);
+  --sidebar-width: 260px;
+  --sidebar-width-collapsed: 76px;
+  --transition-fast: 120ms ease;
+  --transition-medium: 220ms ease;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  background-image: linear-gradient(
+      rgba(0, 0, 0, 0.35),
+      rgba(0, 0, 0, 0.55)
+    ), url("../assets/bg/aurora.jpg");
+  background-size: cover;
+  background-position: center;
+  filter: brightness(1);
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  backdrop-filter: blur(0px);
+  pointer-events: none;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: var(--sidebar-width);
+  background: var(--color-bg);
+  border-right: 1px solid rgba(255, 255, 255, 0.04);
+  padding: 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: relative;
+  transition: width var(--transition-medium);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.sidebar[data-collapsed="true"] {
+  width: var(--sidebar-width-collapsed);
+  align-items: center;
+}
+
+.sidebar__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.sidebar__toggle {
+  font-size: 1.25rem;
+  color: var(--color-text);
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  transition: background var(--transition-fast), transform var(--transition-fast);
+}
+
+.sidebar__toggle:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.sidebar__toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.sidebar__title {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  transition: opacity var(--transition-fast);
+}
+
+.sidebar[data-collapsed="true"] .sidebar__title {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sidebar__link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  color: var(--color-text-muted);
+  letter-spacing: 0.03em;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.sidebar__link:hover,
+.sidebar__link:focus-visible {
+  color: var(--color-text);
+  background: rgba(255, 255, 255, 0.08);
+  outline: none;
+}
+
+.sidebar__link.is-active {
+  background: rgba(90, 161, 255, 0.18);
+  color: var(--color-text);
+}
+
+.sidebar[data-collapsed="true"] .sidebar__text {
+  display: none;
+}
+
+.sidebar[data-collapsed="true"] .sidebar__link {
+  justify-content: center;
+  width: 100%;
+}
+
+.main-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  min-height: 100vh;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 24px 40px 0 40px;
+  pointer-events: none;
+}
+
+.topbar__actions {
+  pointer-events: auto;
+  position: relative;
+}
+
+.avatar-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #2c4bff, #5aa1ff);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  box-shadow: 0 8px 24px rgba(14, 19, 27, 0.45);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.avatar-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 28px rgba(14, 19, 27, 0.55);
+}
+
+.avatar-button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.avatar-button__inner {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  overflow: hidden;
+}
+
+.avatar-button__inner--initials {
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+}
+
+.avatar-button__inner--image {
+  width: 100%;
+  height: 100%;
+}
+
+.avatar-button__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
+}
+
+.avatar-button--image {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.icon {
+  width: 24px;
+  height: 24px;
+  display: block;
+  fill: currentColor;
+}
+
+.dropdown[hidden] {
+  display: none;
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 12px);
+  right: 0;
+  background: rgba(15, 19, 26, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  box-shadow: 0 18px 40px rgba(4, 8, 12, 0.45);
+  min-width: 220px;
+  transform: scale(0.95);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+  padding: 12px;
+  z-index: 10;
+}
+
+.dropdown[data-open="true"] {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.dropdown__item {
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--color-text);
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.dropdown__item:hover,
+.dropdown__item:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  outline: none;
+}
+
+.dropdown__user {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px 10px;
+}
+
+.dropdown__user-name {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.dropdown__user-meta {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.dropdown__separator {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+  margin: 10px 0;
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 24px 80px;
+}
+
+.search-panel {
+  width: min(640px, 90vw);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: center;
+}
+
+.search-form {
+  width: 100%;
+}
+
+.search-form__field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  height: 64px;
+  padding: 0 16px 0 56px;
+  border-radius: 18px;
+  background: var(--color-bg-strong);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 24px 40px rgba(4, 8, 12, 0.35);
+  transition: border var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
+}
+
+.search-form__field:focus-within {
+  border-color: rgba(90, 161, 255, 0.45);
+  box-shadow: 0 28px 52px rgba(9, 16, 25, 0.55);
+}
+
+.search-form__icon {
+  position: absolute;
+  left: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  color: rgba(234, 242, 255, 0.75);
+}
+
+.search-form input[type="search"] {
+  flex: 1;
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--color-text);
+  font-size: 18px;
+  letter-spacing: 0.02em;
+  padding: 0;
+}
+
+.search-form input[type="search"]::placeholder {
+  color: rgba(234, 242, 255, 0.6);
+}
+
+.search-form__filter {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text);
+  transition: background var(--transition-fast);
+}
+
+.search-form__filter:hover,
+.search-form__filter:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  outline: none;
+}
+
+.search-form__filter[data-active="true"] {
+  background: rgba(90, 161, 255, 0.22);
+  color: var(--color-text);
+}
+
+.search-panel__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 20px;
+  height: 40px;
+  border-radius: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.button--primary {
+  background: var(--color-primary);
+  color: #041528;
+  box-shadow: 0 16px 32px rgba(7, 19, 32, 0.4);
+}
+
+.button--primary:hover {
+  background: var(--color-primary-hover);
+  transform: translateY(-1px);
+}
+
+.button--primary:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.button--ghost {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text);
+}
+
+.button--ghost:hover,
+.button--ghost:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  outline: none;
+}
+
+.search-panel__result {
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  min-height: 1.2em;
+}
+
+.popover[hidden] {
+  display: none;
+}
+
+.popover {
+  position: fixed;
+  z-index: 15;
+  min-width: 260px;
+  background: rgba(18, 22, 30, 0.95);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 48px rgba(4, 8, 12, 0.45);
+  padding: 16px;
+  transform-origin: top right;
+  transform: scale(0.92);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+}
+
+.popover[data-open="true"] {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.popover__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.popover__header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.popover__close {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text);
+}
+
+.popover__close:hover,
+.popover__close:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  outline: none;
+}
+
+.popover__body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field__label {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.02em;
+}
+
+.field__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.field select,
+.field input,
+.field textarea {
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(19, 23, 30, 0.75);
+  padding: 10px 12px;
+  color: var(--color-text);
+  transition: border var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.field select:focus-visible,
+.field input:focus-visible,
+.field textarea:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-color: rgba(90, 161, 255, 0.45);
+}
+
+.popover__footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.modal[data-open="true"] {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 6, 12, 0.65);
+  backdrop-filter: blur(8px);
+}
+
+.modal__dialog {
+  position: relative;
+  z-index: 1;
+  width: min(640px, 92vw);
+  max-height: 90vh;
+  overflow: hidden;
+  border-radius: 24px;
+  background: rgba(15, 19, 26, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 32px 60px rgba(4, 8, 12, 0.6);
+  display: flex;
+  flex-direction: column;
+}
+
+.modal__header {
+  padding: 24px 28px 0 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.modal__header h2 {
+  margin: 0;
+}
+
+.modal__close {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text);
+}
+
+.modal__close:hover,
+.modal__close:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  outline: none;
+}
+
+.modal__form {
+  padding: 24px 28px 28px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.field--enchantments {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 18px;
+  background: rgba(19, 23, 30, 0.6);
+}
+
+.enchantments {
+  display: grid;
+  gap: 12px;
+}
+
+.enchantment-option {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(25, 30, 40, 0.6);
+  border: 1px solid transparent;
+  transition: border var(--transition-fast), background var(--transition-fast);
+}
+
+.enchantment-option.is-active {
+  border-color: rgba(90, 161, 255, 0.45);
+  background: rgba(34, 42, 56, 0.7);
+}
+
+.enchantment-option label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.enchantment-option__max {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.enchantment-option__level {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.enchantment-option__level label {
+  font-size: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.enchantment-option input[type="number"] {
+  width: 100px;
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.profile-panel[hidden] {
+  display: none;
+}
+
+.profile-panel {
+  position: fixed;
+  top: 96px;
+  right: 40px;
+  z-index: 25;
+  background: rgba(14, 18, 26, 0.96);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 48px rgba(4, 8, 12, 0.5);
+  transform: scale(0.92);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+  max-width: 280px;
+}
+
+.profile-panel[data-open="true"] {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.profile-panel__content {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.profile-panel__content h3 {
+  margin: 0;
+}
+
+.profile-panel__content dl {
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.profile-panel__content dt {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.profile-panel__content dd {
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.toast-region {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 40;
+}
+
+.toast {
+  background: rgba(18, 22, 30, 0.95);
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 12px 18px;
+  min-width: 220px;
+  box-shadow: 0 18px 40px rgba(4, 8, 12, 0.45);
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+}
+
+.toast[data-show="true"] {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast__message {
+  flex: 1;
+  font-size: 0.9rem;
+}
+
+.toast__close {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text);
+}
+
+.toast__close:hover,
+.toast__close:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  outline: none;
+}
+
+@media (max-width: 1280px) {
+  .topbar {
+    padding-right: 28px;
+  }
+
+  .profile-panel {
+    right: 28px;
+  }
+}
+
+@media (max-width: 1024px) {
+  .sidebar {
+    width: var(--sidebar-width-collapsed);
+    align-items: center;
+  }
+
+  .sidebar__title,
+  .sidebar__text {
+    display: none;
+  }
+
+  .content {
+    padding-top: 48px;
+  }
+
+  .topbar {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+@media (max-width: 768px) {
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .modal__dialog {
+    max-height: 95vh;
+  }
+
+  .toast-region {
+    bottom: 16px;
+    right: 16px;
+  }
+
+  .profile-panel {
+    right: 16px;
+  }
+}
+
+@media (max-width: 560px) {
+  .search-form__field {
+    padding-left: 52px;
+    height: 58px;
+  }
+
+  .search-panel {
+    gap: 16px;
+  }
+
+  .button {
+    width: 100%;
+  }
+}
+
+:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}


### PR DESCRIPTION
## Summary
- add a standalone /db page with sidebar navigation, search card, avatar dropdown, and modal scaffolding
- implement ES module app logic for Supabase auth, filters, debounced search, and item creation flow
- provide tailored styling for aurora background, responsive sidebar, dialogs, popovers, and toast notifications

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c86d3b2e48832483a44c26ccc6d977