### PR TITLE
Create public item listing experience

### DIFF
--- a/public/db/index.html
+++ b/public/db/index.html
@@ -3,133 +3,44 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>OP-Item Datenbank</title>
+    <title>OP Item Datenbank</title>
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
-    <svg aria-hidden="true" style="position: absolute; width: 0; height: 0; overflow: hidden">
-      <symbol id="icon-search" viewBox="0 0 24 24">
-        <path
-          fill="currentColor"
-          d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.71.71l.27.28v.79l5 5a1 1 0 0 0 1.41-1.41zm-6 0a4.5 4.5 0 1 1 4.5-4.5 4.5 4.5 0 0 1-4.5 4.5"
-        />
-      </symbol>
-      <symbol id="icon-filter" viewBox="0 0 24 24">
-        <path
-          fill="currentColor"
-          d="M3 5a1 1 0 0 1 1-1h16a1 1 0 0 1 .8 1.6l-5.2 6.93V19a1 1 0 0 1-.55.89l-4 2A1 1 0 0 1 9 21v-7.47L3.2 5.6A1 1 0 0 1 3 5"
-        />
-      </symbol>
-      <symbol id="icon-user" viewBox="0 0 24 24">
-        <path
-          fill="currentColor"
-          d="M12 2a6 6 0 1 1 0 12 6 6 0 0 1 0-12m0 14c4.2 0 8 1.89 8 4.2V22H4v-1.8C4 17.89 7.8 16 12 16"
-        />
-      </symbol>
-    </svg>
-
-    <div class="app-shell">
-      <aside class="sidebar" data-collapsed="false">
-        <div class="sidebar__header">
-          <button
-            class="sidebar__toggle"
-            type="button"
-            aria-label="Navigation ein-/ausklappen"
-            aria-expanded="true"
-          >
-            ☰
-          </button>
-          <span class="sidebar__title">OP&nbsp;Tools</span>
+    <header class="page-header">
+      <div class="page-header__inner">
+        <div class="brand">
+          <div class="brand__icon" aria-hidden="true">⚔️</div>
+          <div class="brand__text">
+            <p class="brand__eyebrow">OP Item Datenbank</p>
+            <h1 class="brand__title">Legendäre Ausrüstung entdecken</h1>
+            <p class="brand__lead">
+              Durchsuche die Sammlung, filtere nach Typ und Seltenheit und entdecke neue Favoriten.
+            </p>
+          </div>
         </div>
-        <nav class="sidebar__nav" aria-label="Hauptnavigation">
-          <a class="sidebar__link" href="#">
-            <span class="sidebar__icon" aria-hidden="true">🏠</span>
-            <span class="sidebar__text">Startseite</span>
-          </a>
-          <a class="sidebar__link is-active" href="#" aria-current="page">
-            <span class="sidebar__icon" aria-hidden="true">📦</span>
-            <span class="sidebar__text">OP-Item Datenbank</span>
-          </a>
-        </nav>
-      </aside>
-
-      <div class="main-area">
-        <header class="topbar">
-          <div class="topbar__spacer" aria-hidden="true"></div>
-          <div class="topbar__actions">
-            <button
-              class="avatar-button"
-              type="button"
-              id="avatarButton"
-              aria-haspopup="true"
-              aria-expanded="false"
-              aria-label="Benutzerkonto"
-            >
-              <span class="avatar-button__inner" aria-hidden="true">
-                <svg class="icon" data-icon="user" focusable="false" aria-hidden="true"></svg>
-              </span>
-            </button>
-          </div>
-          <div class="dropdown" id="avatarDropdown" role="menu" aria-labelledby="avatarButton" hidden>
-            <div class="dropdown__content" role="none">
-              <button class="dropdown__item" type="button" data-action="login" role="menuitem">
-                Mit Discord anmelden
-              </button>
-            </div>
-          </div>
-        </header>
-
-        <main class="content" role="main">
-          <section class="search-panel" aria-label="Item Suche">
-            <form class="search-form" id="searchForm" role="search">
-              <label class="visually-hidden" for="searchInput">Item suchen</label>
-              <div class="search-form__field">
-                <span class="search-form__icon" aria-hidden="true">
-                  <svg class="icon" data-icon="search" focusable="false"></svg>
-                </span>
-                <input
-                  id="searchInput"
-                  name="search"
-                  type="search"
-                  placeholder="Item suchen…"
-                  autocomplete="off"
-                  aria-label="Item suchen"
-                />
-                <button
-                  class="search-form__filter"
-                  type="button"
-                  id="filterButton"
-                  aria-haspopup="dialog"
-                  aria-expanded="false"
-                  aria-controls="filterPopover"
-                >
-                  <svg class="icon" data-icon="filter" focusable="false"></svg>
-                  <span class="visually-hidden">Filter öffnen</span>
-                </button>
-              </div>
-            </form>
-            <div class="search-panel__actions">
-              <button class="button button--primary" id="addItemButton" type="button">
-                Item hinzufügen
-              </button>
-              <p class="search-panel__result" id="resultInfo" aria-live="polite"></p>
-            </div>
-          </section>
-        </main>
+        <form id="searchForm" class="search" role="search" autocomplete="off">
+          <label class="sr-only" for="searchInput">Items durchsuchen</label>
+          <input
+            id="searchInput"
+            class="search__input"
+            type="search"
+            name="q"
+            placeholder="Nach Items suchen…"
+            aria-label="Items durchsuchen"
+            autocomplete="off"
+          />
+        </form>
       </div>
-    </div>
+    </header>
 
-    <div class="popover" id="filterPopover" role="dialog" aria-modal="false" hidden>
-      <form id="filterForm" class="popover__form">
-        <header class="popover__header">
-          <h2>Filter</h2>
-          <button class="popover__close" type="button" data-close-filter aria-label="Filter schließen">×</button>
-        </header>
-        <div class="popover__body">
-          <label class="field">
-            <span class="field__label">Item-Art</span>
-            <select name="item_type" aria-label="Item-Art auswählen">
-              <option value="">Alle</option>
+    <main class="page-main">
+      <section class="toolbar" aria-label="Filter">
+        <form id="filterForm" class="filters" autocomplete="off">
+          <label class="filter">
+            <span class="filter__label">Item-Typ</span>
+            <select id="typeFilter" name="type">
+              <option value="">Alle Typen</option>
               <option value="sword">Sword</option>
               <option value="axe">Axe</option>
               <option value="bow">Bow</option>
@@ -138,126 +49,80 @@
               <option value="trinket">Trinket</option>
             </select>
           </label>
-          <label class="field">
-            <span class="field__label">Seltenheit</span>
-            <select name="rarity" aria-label="Seltenheit auswählen">
-              <option value="">Alle</option>
+          <label class="filter">
+            <span class="filter__label">Seltenheit</span>
+            <select id="rarityFilter" name="rarity">
+              <option value="">Alle Seltenheiten</option>
               <option value="common">Common</option>
+              <option value="uncommon">Uncommon</option>
               <option value="rare">Rare</option>
               <option value="epic">Epic</option>
               <option value="legendary">Legendary</option>
               <option value="mythic">Mythic</option>
             </select>
           </label>
-        </div>
-        <footer class="popover__footer">
-          <button class="button button--ghost" type="button" id="resetFilters">Zurücksetzen</button>
-          <button class="button button--primary" type="submit">Übernehmen</button>
-        </footer>
-      </form>
-    </div>
-
-    <div class="modal" id="itemModal" role="dialog" aria-modal="true" aria-labelledby="itemModalTitle" hidden>
-      <div class="modal__backdrop" data-modal-close></div>
-      <div class="modal__dialog" role="document">
-        <header class="modal__header">
-          <h2 id="itemModalTitle">Item hinzufügen</h2>
-          <button class="modal__close" type="button" aria-label="Modal schließen" data-modal-close>
-            ×
-          </button>
-        </header>
-        <form class="modal__form" id="itemForm">
-          <div class="form-grid">
-            <label class="field">
-              <span class="field__label">Name</span>
-              <input type="text" name="name" required autocomplete="off" />
-            </label>
-            <label class="field">
-              <span class="field__label">Item-Art</span>
-              <select name="item_type" required>
-                <option value="" disabled selected hidden>Bitte wählen</option>
-                <option value="sword">Sword</option>
-                <option value="axe">Axe</option>
-                <option value="bow">Bow</option>
-                <option value="armor">Armor</option>
-                <option value="tool">Tool</option>
-                <option value="trinket">Trinket</option>
-              </select>
-            </label>
-            <label class="field">
-              <span class="field__label">Seltenheit</span>
-              <select name="rarity" required>
-                <option value="" disabled selected hidden>Bitte wählen</option>
-                <option value="common">Common</option>
-                <option value="uncommon">Uncommon</option>
-                <option value="rare">Rare</option>
-                <option value="epic">Epic</option>
-                <option value="legendary">Legendary</option>
-                <option value="mythic">Mythic</option>
-              </select>
-            </label>
-            <label class="field">
-              <span class="field__label">Stern-Level</span>
-              <input type="number" name="star_level" min="0" step="1" value="0" />
-            </label>
-            <label class="field">
-              <span class="field__label">Preis</span>
-              <input type="number" name="price" min="0" step="0.01" placeholder="Optional" />
-            </label>
-            <label class="field">
-              <span class="field__label">Bild-URL</span>
-              <input type="url" name="image_url" placeholder="https://…" />
-            </label>
-          </div>
-          <fieldset class="field field--enchantments">
-            <legend class="field__label">Verzauberungen</legend>
-            <p class="field__hint" id="enchantmentHint">
-              Lade Verzauberungen…
-            </p>
-            <div class="enchantments" id="enchantmentsList" role="group" aria-labelledby="enchantmentHint"></div>
-          </fieldset>
-          <div class="modal__actions">
-            <button class="button button--ghost" type="button" data-modal-close>Abbrechen</button>
-            <button class="button button--primary" type="submit" id="modalSubmit">Speichern</button>
-          </div>
         </form>
-      </div>
-    </div>
+        <p id="resultInfo" class="toolbar__info" aria-live="polite"></p>
+      </section>
 
-    <div class="profile-panel" id="profilePanel" role="dialog" aria-modal="false" hidden>
-      <div class="profile-panel__content">
-        <h3>Profil</h3>
-        <dl>
-          <div>
-            <dt>E-Mail</dt>
-            <dd id="profileEmail">-</dd>
-          </div>
-          <div>
-            <dt>User-ID</dt>
-            <dd id="profileId">-</dd>
-          </div>
-        </dl>
-        <button class="button button--ghost" type="button" data-close-profile>Schließen</button>
-      </div>
-    </div>
+      <section class="results" aria-label="Suchergebnisse">
+        <div id="cardGrid" class="card-grid" role="list"></div>
+        <button id="loadMoreButton" class="load-more" type="button">Mehr laden</button>
+      </section>
+    </main>
 
-    <div class="toast-region" id="toastRegion" aria-live="polite" aria-atomic="false"></div>
+    <aside id="detailView" class="detail-view" aria-hidden="true" hidden>
+      <div class="detail-view__backdrop" data-close-detail></div>
+      <article class="detail-card" role="dialog" aria-modal="true" aria-labelledby="detailTitle">
+        <button class="detail-card__close" type="button" aria-label="Details schließen" data-close-detail>
+          &times;
+        </button>
+        <div class="detail-card__top">
+          <figure class="detail-card__media" id="detailMedia">
+            <img id="detailImage" alt="" />
+            <div class="detail-card__media-fallback" id="detailFallback" aria-hidden="true"></div>
+          </figure>
+          <header class="detail-card__summary">
+            <p class="detail-card__eyebrow" id="detailSubtitle"></p>
+            <h2 class="detail-card__title" id="detailTitle">Item</h2>
+            <div class="detail-card__stars" id="detailStars" role="img" aria-live="polite"></div>
+            <dl class="detail-card__meta">
+              <div>
+                <dt>Seltenheit</dt>
+                <dd id="detailRarity">-</dd>
+              </div>
+              <div>
+                <dt>Veröffentlicht</dt>
+                <dd>
+                  <span id="detailReleaseRelative">-</span>
+                  <span id="detailReleaseAbsolute" class="detail-card__muted"></span>
+                </dd>
+              </div>
+              <div>
+                <dt>Typ</dt>
+                <dd id="detailType">-</dd>
+              </div>
+            </dl>
+          </header>
+        </div>
+        <div class="detail-card__body">
+          <section class="detail-section" id="detailDescriptionSection" hidden>
+            <h3>Beschreibung</h3>
+            <p id="detailDescription"></p>
+          </section>
+          <section class="detail-section" id="detailPropertiesSection">
+            <h3>Eigenschaften</h3>
+            <dl class="detail-list" id="detailProperties"></dl>
+          </section>
+          <section class="detail-section" id="detailEnchantmentsSection">
+            <h3>Verzauberungen</h3>
+            <ul class="detail-enchantments" id="detailEnchantments"></ul>
+          </section>
+          <p class="detail-status" id="detailStatus" aria-live="polite"></p>
+        </div>
+      </article>
+    </aside>
 
-    <script>
-      // TODO: Hier PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY und optional API_BASE eintragen.
-      window.ENV = window.ENV || {
-        PUBLIC_SUPABASE_URL: "",
-        PUBLIC_SUPABASE_ANON_KEY: "",
-        API_BASE: ""
-      };
-    </script>
     <script type="module" src="./app.js"></script>
-
-    <!--
-      README-Snippet:
-      - Lokales Preview: `wrangler pages dev ./output`
-      - Vor dem Deploy `PUBLIC_SUPABASE_URL` und `PUBLIC_SUPABASE_ANON_KEY` in window.ENV setzen.
-      - Discord OAuth Redirect-URL in Supabase/Discord auf `https://<deine-domain>/db/` (bzw. lokal `http://127.0.0.1:8788/db/`) konfigurieren.
-    -->
   </body>
 </html>

--- a/public/db/style.css
+++ b/public/db/style.css
@@ -1,93 +1,100 @@
-/* Modern Normalize (lokal) */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
-html {
-  line-height: 1.15;
-  -webkit-text-size-adjust: 100%;
+:root {
+  color-scheme: dark;
+  --font-body: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --color-background: #070d1a;
+  --color-surface: rgba(15, 23, 42, 0.7);
+  --color-surface-strong: rgba(15, 23, 42, 0.92);
+  --color-border: rgba(148, 163, 184, 0.2);
+  --color-border-strong: rgba(148, 163, 184, 0.35);
+  --color-text: #f8fafc;
+  --color-text-muted: rgba(203, 213, 225, 0.75);
+  --color-primary: #60a5fa;
+  --shadow-lg: 0 30px 60px rgba(7, 14, 32, 0.4);
+  --shadow-md: 0 20px 35px rgba(8, 16, 36, 0.32);
+  --radius-lg: 24px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --max-width: min(1120px, 92vw);
+  --transition: 180ms ease;
 }
 
 body {
   margin: 0;
-  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
-  font-size: 16px;
-  color: #eaf2ff;
-  background-color: #05080d;
   min-height: 100vh;
-  position: relative;
-  overflow-x: hidden;
+  font-family: var(--font-body);
+  background: radial-gradient(circle at top, rgba(37, 99, 235, 0.22), transparent 55%),
+    radial-gradient(circle at 20% 120%, rgba(236, 72, 153, 0.18), transparent 45%),
+    linear-gradient(160deg, #020617 0%, #0f172a 45%, #020617 100%);
+  color: var(--color-text);
+  letter-spacing: 0.01em;
+  line-height: 1.6;
 }
 
-main {
+body[data-detail-open='true'] {
+  overflow: hidden;
+}
+
+img {
+  max-width: 100%;
   display: block;
 }
 
 a {
-  background-color: transparent;
   color: inherit;
   text-decoration: none;
 }
 
-img {
-  border-style: none;
-}
-
 button,
 input,
-select,
-textarea {
+select {
   font: inherit;
   color: inherit;
 }
 
 button {
-  border: none;
-  background: none;
   cursor: pointer;
+  border: none;
 }
 
-:root {
-  color-scheme: dark;
-  --color-bg: rgba(11, 15, 20, 0.8);
-  --color-bg-strong: rgba(20, 24, 30, 0.65);
-  --color-bg-highlight: rgba(28, 34, 45, 0.75);
-  --color-border: rgba(255, 255, 255, 0.08);
-  --color-text: #eaf2ff;
-  --color-text-muted: rgba(234, 242, 255, 0.75);
-  --color-primary: #5aa1ff;
-  --color-primary-hover: #78b4ff;
-  --focus-ring: 0 0 0 2px rgba(90, 161, 255, 0.3);
-  --sidebar-width: 260px;
-  --sidebar-width-collapsed: 76px;
-  --transition-fast: 120ms ease;
-  --transition-medium: 220ms ease;
+input,
+select {
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.72);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+  transition: border-color var(--transition), box-shadow var(--transition);
+  width: 100%;
+  color: var(--color-text);
 }
 
-body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  z-index: -2;
-  background-image: linear-gradient(
-      rgba(0, 0, 0, 0.35),
-      rgba(0, 0, 0, 0.55)
-    ), url("../assets/bg/aurora.jpg");
-  background-size: cover;
-  background-position: center;
-  filter: brightness(1);
+input:focus,
+select:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.8);
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.18);
 }
 
-body::after {
-  content: "";
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  backdrop-filter: blur(0px);
-  pointer-events: none;
+select {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, rgba(96, 165, 250, 0.7) 0),
+    linear-gradient(135deg, rgba(96, 165, 250, 0.7) 50%, transparent 0);
+  background-position: calc(100% - 18px) calc(1.1em), calc(100% - 13px) calc(1.1em);
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  padding-right: 2.75rem;
 }
 
-.visually-hidden {
+::placeholder {
+  color: rgba(148, 163, 184, 0.65);
+}
+
+.sr-only {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -99,833 +106,590 @@ body::after {
   border: 0;
 }
 
-.app-shell {
+.page-header {
+  padding: clamp(2.5rem, 8vw, 4.5rem) 0 clamp(1.75rem, 6vw, 3rem);
+}
+
+.page-header__inner {
+  width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: clamp(2rem, 6vw, 3rem);
+}
+
+.brand {
   display: flex;
-  min-height: 100vh;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  align-items: flex-start;
 }
 
-.sidebar {
-  width: var(--sidebar-width);
-  background: var(--color-bg);
-  border-right: 1px solid rgba(255, 255, 255, 0.04);
-  padding: 24px 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-  position: relative;
-  transition: width var(--transition-medium);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
+.brand__icon {
+  width: clamp(64px, 10vw, 86px);
+  height: clamp(64px, 10vw, 86px);
+  border-radius: 32px;
+  background: linear-gradient(145deg, rgba(96, 165, 250, 0.25), rgba(30, 64, 175, 0.35));
+  display: grid;
+  place-items: center;
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  box-shadow: inset 0 0 30px rgba(96, 165, 250, 0.25), 0 15px 35px rgba(2, 6, 23, 0.35);
 }
 
-.sidebar[data-collapsed="true"] {
-  width: var(--sidebar-width-collapsed);
-  align-items: center;
-}
-
-.sidebar__header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  justify-content: space-between;
-}
-
-.sidebar__toggle {
-  font-size: 1.25rem;
-  color: var(--color-text);
-  width: 40px;
-  height: 40px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.04);
-  transition: background var(--transition-fast), transform var(--transition-fast);
-}
-
-.sidebar__toggle:hover {
-  background: rgba(255, 255, 255, 0.08);
-}
-
-.sidebar__toggle:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
-}
-
-.sidebar__title {
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  white-space: nowrap;
-  transition: opacity var(--transition-fast);
-}
-
-.sidebar[data-collapsed="true"] .sidebar__title {
-  opacity: 0;
-  pointer-events: none;
-}
-
-.sidebar__nav {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.sidebar__link {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 14px;
-  border-radius: 12px;
-  color: var(--color-text-muted);
-  letter-spacing: 0.03em;
-  transition: background var(--transition-fast), color var(--transition-fast);
-}
-
-.sidebar__link:hover,
-.sidebar__link:focus-visible {
-  color: var(--color-text);
-  background: rgba(255, 255, 255, 0.08);
-  outline: none;
-}
-
-.sidebar__link.is-active {
-  background: rgba(90, 161, 255, 0.18);
-  color: var(--color-text);
-}
-
-.sidebar[data-collapsed="true"] .sidebar__text {
-  display: none;
-}
-
-.sidebar[data-collapsed="true"] .sidebar__link {
-  justify-content: center;
-  width: 100%;
-}
-
-.main-area {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  min-height: 100vh;
-}
-
-.topbar {
-  position: sticky;
-  top: 0;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  padding: 24px 40px 0 40px;
-  pointer-events: none;
-}
-
-.topbar__actions {
-  pointer-events: auto;
-  position: relative;
-}
-
-.avatar-button {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #2c4bff, #5aa1ff);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: #fff;
-  box-shadow: 0 8px 24px rgba(14, 19, 27, 0.45);
-  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-.avatar-button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 28px rgba(14, 19, 27, 0.55);
-}
-
-.avatar-button:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
-}
-
-.avatar-button__inner {
-  width: 24px;
-  height: 24px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  overflow: hidden;
-}
-
-.avatar-button__inner--initials {
-  font-weight: 700;
+.brand__eyebrow {
   font-size: 0.85rem;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+  margin: 0 0 0.6rem;
 }
 
-.avatar-button__inner--image {
+.brand__title {
+  font-size: clamp(2.3rem, 5.4vw, 3.1rem);
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.brand__lead {
+  max-width: 38ch;
+  color: var(--color-text-muted);
+  margin: 0.75rem 0 0;
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  max-width: 420px;
+}
+
+.search__input {
   width: 100%;
-  height: 100%;
+  font-size: 1.05rem;
+  padding-left: 3.2rem;
+  background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="%23a5b4fc" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" viewBox="0 0 24 24"%3E%3Ccircle cx="11" cy="11" r="7"/%3E%3Cpath d="m20 20-3.5-3.5"/%3E%3C/svg%3E');
+  background-repeat: no-repeat;
+  background-position: 1rem 50%;
+  background-size: 1.15rem;
 }
 
-.avatar-button__image {
+.page-main {
+  width: var(--max-width);
+  margin: 0 auto clamp(3rem, 8vw, 5rem);
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.filters {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.filter__label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-text-muted);
+}
+
+.toolbar__info {
+  min-height: 1.25rem;
+  color: rgba(148, 163, 184, 0.9);
+  font-size: 0.95rem;
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.card-grid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.2rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card-grid[data-state='empty'] {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  color: var(--color-text-muted);
+  padding: 4rem 1rem;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: var(--radius-lg);
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.empty-message {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.5;
+}
+
+.item-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid rgba(96, 165, 250, 0.08);
+  box-shadow: var(--shadow-md);
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+  position: relative;
+  text-align: left;
+  width: 100%;
+}
+
+.item-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid transparent;
+  transition: border-color var(--transition);
+  pointer-events: none;
+}
+
+.item-card:hover,
+.item-card:focus-visible {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-lg);
+}
+
+.item-card:focus-visible::after {
+  border-color: rgba(96, 165, 250, 0.55);
+}
+
+.item-card__media {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.25), rgba(2, 6, 23, 0.6));
+}
+
+.item-card__media img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: 50%;
-  display: block;
+  transition: transform var(--transition);
 }
 
-.avatar-button--image {
-  background: rgba(255, 255, 255, 0.18);
+.item-card:hover .item-card__media img {
+  transform: scale(1.05);
 }
 
-.icon {
-  width: 24px;
-  height: 24px;
-  display: block;
-  fill: currentColor;
+.item-card__placeholder {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.5rem;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.25), rgba(15, 23, 42, 0.7));
+  color: rgba(226, 232, 240, 0.85);
 }
 
-.dropdown[hidden] {
+.item-card__media[data-empty='true'] img {
   display: none;
 }
 
-.dropdown {
-  position: absolute;
-  top: calc(100% + 12px);
-  right: 0;
-  background: rgba(15, 19, 26, 0.94);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 16px;
-  box-shadow: 0 18px 40px rgba(4, 8, 12, 0.45);
-  min-width: 220px;
-  transform: scale(0.95);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity var(--transition-fast), transform var(--transition-fast);
-  padding: 12px;
-  z-index: 10;
+.item-card__media[data-empty='true'] .item-card__placeholder {
+  display: flex;
 }
 
-.dropdown[data-open="true"] {
-  opacity: 1;
-  transform: scale(1);
-  pointer-events: auto;
-}
-
-.dropdown__item {
-  width: 100%;
-  text-align: left;
-  padding: 10px 12px;
-  border-radius: 10px;
-  background: transparent;
-  color: var(--color-text);
-  transition: background var(--transition-fast), color var(--transition-fast);
-}
-
-.dropdown__item:hover,
-.dropdown__item:focus-visible {
-  background: rgba(255, 255, 255, 0.08);
-  outline: none;
-}
-
-.dropdown__user {
+.item-card__body {
+  padding: 1.25rem 1.35rem 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 8px 10px 10px;
+  gap: 0.85rem;
 }
 
-.dropdown__user-name {
+.item-card__title {
+  margin: 0;
+  font-size: 1.2rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
 }
 
-.dropdown__user-meta {
+.item-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.rarity-badge {
+  padding: 0.2rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 600;
+  background: rgba(96, 165, 250, 0.16);
+  color: rgba(191, 219, 254, 0.88);
+}
+
+.rarity-badge[data-rarity='common'] {
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.rarity-badge[data-rarity='uncommon'] {
+  background: rgba(34, 197, 94, 0.16);
+  color: rgba(187, 247, 208, 0.9);
+}
+
+.rarity-badge[data-rarity='rare'] {
+  background: rgba(59, 130, 246, 0.16);
+  color: rgba(191, 219, 254, 0.88);
+}
+
+.rarity-badge[data-rarity='epic'] {
+  background: rgba(129, 140, 248, 0.18);
+  color: rgba(199, 210, 254, 0.95);
+}
+
+.rarity-badge[data-rarity='legendary'] {
+  background: rgba(245, 158, 11, 0.22);
+  color: rgba(253, 230, 138, 0.95);
+}
+
+.rarity-badge[data-rarity='mythic'] {
+  background: rgba(236, 72, 153, 0.22);
+  color: rgba(251, 207, 232, 0.92);
+}
+
+.item-card__type {
   font-size: 0.85rem;
-  color: var(--color-text-muted);
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.14);
+  color: rgba(226, 232, 240, 0.85);
 }
 
-.dropdown__separator {
-  height: 1px;
-  background: rgba(255, 255, 255, 0.08);
-  margin: 10px 0;
-}
-
-.content {
-  flex: 1;
+.item-card__stars {
   display: flex;
+  gap: 0.2rem;
   align-items: center;
-  justify-content: center;
-  padding: 64px 24px 80px;
+  color: #facc15;
+  font-size: 1rem;
+  letter-spacing: 0.1em;
 }
 
-.search-panel {
-  width: min(640px, 90vw);
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  align-items: center;
+.item-card__stars[data-count='0'] {
+  color: rgba(148, 163, 184, 0.7);
 }
 
-.search-form {
-  width: 100%;
+.load-more {
+  align-self: center;
+  padding: 0.9rem 2.6rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.8), rgba(37, 99, 235, 0.95));
+  color: #0b1120;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  transition: transform var(--transition), box-shadow var(--transition), filter var(--transition);
+  box-shadow: 0 15px 40px rgba(59, 130, 246, 0.25);
+  border: 0;
 }
 
-.search-form__field {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  width: 100%;
-  height: 64px;
-  padding: 0 16px 0 56px;
-  border-radius: 18px;
-  background: var(--color-bg-strong);
-  border: 1px solid var(--color-border);
-  box-shadow: 0 24px 40px rgba(4, 8, 12, 0.35);
-  transition: border var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
-}
-
-.search-form__field:focus-within {
-  border-color: rgba(90, 161, 255, 0.45);
-  box-shadow: 0 28px 52px rgba(9, 16, 25, 0.55);
-}
-
-.search-form__icon {
-  position: absolute;
-  left: 20px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  pointer-events: none;
-  color: rgba(234, 242, 255, 0.75);
-}
-
-.search-form input[type="search"] {
-  flex: 1;
-  width: 100%;
-  background: transparent;
-  border: none;
-  color: var(--color-text);
-  font-size: 18px;
-  letter-spacing: 0.02em;
-  padding: 0;
-}
-
-.search-form input[type="search"]::placeholder {
-  color: rgba(234, 242, 255, 0.6);
-}
-
-.search-form__filter {
-  width: 44px;
-  height: 44px;
-  border-radius: 12px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--color-text);
-  transition: background var(--transition-fast);
-}
-
-.search-form__filter:hover,
-.search-form__filter:focus-visible {
-  background: rgba(255, 255, 255, 0.18);
+.load-more:hover:not([disabled]),
+.load-more:focus-visible:not([disabled]) {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 45px rgba(59, 130, 246, 0.3);
+  filter: brightness(1.08);
   outline: none;
 }
 
-.search-form__filter[data-active="true"] {
-  background: rgba(90, 161, 255, 0.22);
-  color: var(--color-text);
-}
-
-.search-panel__actions {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  align-items: center;
-}
-
-.button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 0 20px;
-  height: 40px;
-  border-radius: 12px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-.button:disabled {
+.load-more[disabled] {
+  cursor: wait;
   opacity: 0.6;
-  cursor: not-allowed;
-  box-shadow: none;
 }
 
-.button--primary {
-  background: var(--color-primary);
-  color: #041528;
-  box-shadow: 0 16px 32px rgba(7, 19, 32, 0.4);
-}
-
-.button--primary:hover {
-  background: var(--color-primary-hover);
-  transform: translateY(-1px);
-}
-
-.button--primary:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
-}
-
-.button--ghost {
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--color-text);
-}
-
-.button--ghost:hover,
-.button--ghost:focus-visible {
-  background: rgba(255, 255, 255, 0.18);
-  outline: none;
-}
-
-.search-panel__result {
-  font-size: 0.95rem;
-  color: var(--color-text-muted);
-  min-height: 1.2em;
-}
-
-.popover[hidden] {
-  display: none;
-}
-
-.popover {
-  position: fixed;
-  z-index: 15;
-  min-width: 260px;
-  background: rgba(18, 22, 30, 0.95);
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 18px 48px rgba(4, 8, 12, 0.45);
-  padding: 16px;
-  transform-origin: top right;
-  transform: scale(0.92);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity var(--transition-fast), transform var(--transition-fast);
-}
-
-.popover[data-open="true"] {
-  opacity: 1;
-  transform: scale(1);
-  pointer-events: auto;
-}
-
-.popover__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 12px;
-}
-
-.popover__header h2 {
-  margin: 0;
-  font-size: 1.05rem;
-}
-
-.popover__close {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--color-text);
-}
-
-.popover__close:hover,
-.popover__close:focus-visible {
-  background: rgba(255, 255, 255, 0.18);
-  outline: none;
-}
-
-.popover__body {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.field__label {
-  font-size: 0.9rem;
-  color: var(--color-text-muted);
-  letter-spacing: 0.02em;
-}
-
-.field__hint {
-  margin: 0;
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-}
-
-.field select,
-.field input,
-.field textarea {
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(19, 23, 30, 0.75);
-  padding: 10px 12px;
-  color: var(--color-text);
-  transition: border var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-.field select:focus-visible,
-.field input:focus-visible,
-.field textarea:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
-  border-color: rgba(90, 161, 255, 0.45);
-}
-
-.popover__footer {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  margin-top: 18px;
-}
-
-.modal[hidden] {
-  display: none;
-}
-
-.modal {
+.detail-view {
   position: fixed;
   inset: 0;
-  z-index: 30;
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: center;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity var(--transition-fast);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  z-index: 1000;
 }
 
-.modal[data-open="true"] {
-  pointer-events: auto;
-  opacity: 1;
+.detail-view[aria-hidden='false'] {
+  display: flex;
 }
 
-.modal__backdrop {
+.detail-view__backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(2, 6, 12, 0.65);
-  backdrop-filter: blur(8px);
+  background: rgba(2, 6, 23, 0.78);
+  backdrop-filter: blur(6px);
 }
 
-.modal__dialog {
+.detail-card {
   position: relative;
-  z-index: 1;
-  width: min(640px, 92vw);
-  max-height: 90vh;
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border-strong);
+  box-shadow: 0 32px 70px rgba(7, 12, 31, 0.58);
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  width: min(860px, 100%);
+  max-height: min(92vh, 720px);
   overflow: hidden;
-  border-radius: 24px;
-  background: rgba(15, 19, 26, 0.95);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 32px 60px rgba(4, 8, 12, 0.6);
   display: flex;
   flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2rem);
+  z-index: 1;
 }
 
-.modal__header {
-  padding: 24px 28px 0 28px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.modal__header h2 {
-  margin: 0;
-}
-
-.modal__close {
-  width: 36px;
-  height: 36px;
+.detail-card__close {
+  position: absolute;
+  top: 1.2rem;
+  right: 1.2rem;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--color-text);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.85);
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 1.6rem;
+  display: grid;
+  place-items: center;
+  transition: transform var(--transition), border-color var(--transition), color var(--transition);
 }
 
-.modal__close:hover,
-.modal__close:focus-visible {
-  background: rgba(255, 255, 255, 0.18);
+.detail-card__close:hover,
+.detail-card__close:focus-visible {
+  transform: scale(1.08);
+  border-color: rgba(96, 165, 250, 0.7);
+  color: #fff;
   outline: none;
 }
 
-.modal__form {
-  padding: 24px 28px 28px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.form-grid {
+.detail-card__top {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 18px;
+  gap: clamp(1.5rem, 4vw, 2rem);
 }
 
-.field--enchantments {
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 16px;
-  padding: 18px;
-  background: rgba(19, 23, 30, 0.6);
+.detail-card__media {
+  position: relative;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  background: linear-gradient(145deg, rgba(96, 165, 250, 0.22), rgba(37, 99, 235, 0.18));
 }
 
-.enchantments {
-  display: grid;
-  gap: 12px;
+.detail-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
-.enchantment-option {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px 12px;
-  border-radius: 12px;
-  background: rgba(25, 30, 40, 0.6);
-  border: 1px solid transparent;
-  transition: border var(--transition-fast), background var(--transition-fast);
-}
-
-.enchantment-option.is-active {
-  border-color: rgba(90, 161, 255, 0.45);
-  background: rgba(34, 42, 56, 0.7);
-}
-
-.enchantment-option label {
-  display: flex;
+.detail-card__media-fallback {
+  position: absolute;
+  inset: 0;
+  display: none;
   align-items: center;
-  gap: 10px;
+  justify-content: center;
+  font-size: clamp(2.8rem, 7vw, 4rem);
+  color: rgba(226, 232, 240, 0.88);
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.3), rgba(15, 23, 42, 0.8));
 }
 
-.enchantment-option__max {
-  margin-left: auto;
-  font-size: 0.8rem;
-  color: var(--color-text-muted);
-}
-
-.enchantment-option__level {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.enchantment-option__level label {
-  font-size: 0.85rem;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.enchantment-option input[type="number"] {
-  width: 100px;
-}
-
-.modal__actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 12px;
-}
-
-.profile-panel[hidden] {
+.detail-card__media[data-empty='true'] img {
   display: none;
 }
 
-.profile-panel {
-  position: fixed;
-  top: 96px;
-  right: 40px;
-  z-index: 25;
-  background: rgba(14, 18, 26, 0.96);
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 18px 48px rgba(4, 8, 12, 0.5);
-  transform: scale(0.92);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity var(--transition-fast), transform var(--transition-fast);
-  max-width: 280px;
-}
-
-.profile-panel[data-open="true"] {
-  opacity: 1;
-  transform: scale(1);
-  pointer-events: auto;
-}
-
-.profile-panel__content {
-  padding: 20px;
+.detail-card__media[data-empty='true'] .detail-card__media-fallback {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
 }
 
-.profile-panel__content h3 {
-  margin: 0;
-}
-
-.profile-panel__content dl {
-  margin: 0;
+.detail-card__summary {
   display: grid;
-  gap: 8px;
+  gap: 0.75rem;
+  align-content: start;
 }
 
-.profile-panel__content dt {
-  font-size: 0.85rem;
+.detail-card__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.detail-card__title {
+  margin: 0;
+  font-size: clamp(1.9rem, 3.8vw, 2.4rem);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.detail-card__stars {
+  display: flex;
+  gap: 0.2rem;
+  color: #facc15;
+  font-size: 1.2rem;
+  letter-spacing: 0.08em;
+}
+
+.detail-card__stars[data-count='0'] {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.detail-card__meta {
+  display: grid;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+}
+
+.detail-card__meta div {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.detail-card__meta dt {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.72rem;
   color: var(--color-text-muted);
 }
 
-.profile-panel__content dd {
+.detail-card__meta dd {
+  margin: 0;
+}
+
+.detail-card__muted {
+  display: block;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.detail-card__body {
+  overflow-y: auto;
+  padding-right: clamp(0rem, 1vw, 0.5rem);
+  display: grid;
+  gap: clamp(1.2rem, 3vw, 1.6rem);
+}
+
+.detail-section h3 {
+  margin: 0 0 0.65rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.detail-section p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.detail-list {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.detail-list__row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.detail-list__row dt {
   margin: 0;
   font-weight: 600;
   letter-spacing: 0.02em;
 }
 
-.toast-region {
-  position: fixed;
-  bottom: 32px;
-  right: 32px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  z-index: 40;
+.detail-list__row dd {
+  margin: 0;
+  color: var(--color-text-muted);
 }
 
-.toast {
-  background: rgba(18, 22, 30, 0.95);
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 12px 18px;
-  min-width: 220px;
-  box-shadow: 0 18px 40px rgba(4, 8, 12, 0.45);
+.detail-enchantments {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.detail-enchantments__item {
   display: flex;
-  gap: 12px;
+  justify-content: space-between;
+  gap: 1rem;
   align-items: center;
-  opacity: 0;
-  transform: translateY(10px);
-  transition: opacity var(--transition-fast), transform var(--transition-fast);
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px solid rgba(96, 165, 250, 0.25);
 }
 
-.toast[data-show="true"] {
-  opacity: 1;
-  transform: translateY(0);
+.detail-enchantments__item span {
+  display: block;
 }
 
-.toast__message {
-  flex: 1;
+.detail-enchantments__level {
+  color: rgba(191, 219, 254, 0.95);
+  font-weight: 600;
+}
+
+.detail-enchantments__empty {
+  color: var(--color-text-muted);
+  padding: 0.25rem 0;
+  font-size: 0.95rem;
+}
+
+.detail-status {
+  margin: 0;
   font-size: 0.9rem;
+  color: var(--color-text-muted);
 }
 
-.toast__close {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--color-text);
-}
-
-.toast__close:hover,
-.toast__close:focus-visible {
-  background: rgba(255, 255, 255, 0.18);
-  outline: none;
-}
-
-@media (max-width: 1280px) {
-  .topbar {
-    padding-right: 28px;
-  }
-
-  .profile-panel {
-    right: 28px;
+@media (min-width: 768px) {
+  .detail-card__top {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+    align-items: start;
   }
 }
 
-@media (max-width: 1024px) {
-  .sidebar {
-    width: var(--sidebar-width-collapsed);
-    align-items: center;
+@media (max-width: 720px) {
+  .brand {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
-  .sidebar__title,
-  .sidebar__text {
-    display: none;
+  .search {
+    max-width: none;
   }
 
-  .content {
-    padding-top: 48px;
+  .detail-card {
+    max-height: 96vh;
+    padding: 1.75rem 1.25rem;
   }
 
-  .topbar {
-    padding-left: 24px;
-    padding-right: 24px;
-  }
-}
-
-@media (max-width: 768px) {
-  .form-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .modal__dialog {
-    max-height: 95vh;
-  }
-
-  .toast-region {
-    bottom: 16px;
-    right: 16px;
-  }
-
-  .profile-panel {
-    right: 16px;
+  .detail-card__close {
+    top: 0.8rem;
+    right: 0.8rem;
   }
 }
 
-@media (max-width: 560px) {
-  .search-form__field {
-    padding-left: 52px;
-    height: 58px;
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
   }
-
-  .search-panel {
-    gap: 16px;
-  }
-
-  .button {
-    width: 100%;
-  }
-}
-
-:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
-}
-
-::-webkit-scrollbar {
-  width: 8px;
-}
-
-::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.12);
-  border-radius: 4px;
-}
-
-::-webkit-scrollbar-track {
-  background: transparent;
 }


### PR DESCRIPTION
## Summary
- replace the database shell with a public listing page featuring a search bar, type/rarity filters, a results grid and a load-more trigger
- add modern responsive styling for the hero header, card grid, badges, pagination control and detail dialog including image fallbacks
- build a lightweight client-side controller that fetches `/api/items` and `/api/search`, applies filters, handles pagination, and renders an accessible detail view without exposing prices

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c88a577b6483248e5d40378f812fe2