### PR TITLE
Add image upload examples for Supabase and R2

### DIFF
--- a/examples/upload/README.md
+++ b/examples/upload/README.md
@@ -1,0 +1,78 @@
+# Image-Uploader Varianten
+
+Dieses Verzeichnis enthält zwei minimal gehaltene Varianten für einen Bild-Upload von eingeloggten Nutzer:innen. Beide Varianten validieren die Datei client- und serverseitig auf `image/*` und eine maximale Größe von 2&nbsp;MB.
+
+## Gemeinsame Voraussetzungen
+
+- Supabase-Projekt mit einer Tabelle `items` (Spalte `image_url` und einer Spalte mit der Nutzer-ID, z.&nbsp;B. `owner_id`).
+- Die im Frontend verwendete Supabase-Anon-Key darf nur auf eigene Datensätze zugreifen (Row Level Security).
+- Die Worker nutzen den Service-Role-Key, um das Token aus dem `Authorization`-Header zu verifizieren.
+
+## Variante A – Supabase Storage
+
+- Erstelle in Supabase einen öffentlichen Storage-Bucket `item-images`.
+- Aktiviere in den Storage-Richtlinien den Zugriff für authentifizierte Nutzer:innen zum Upload in den Unterordner ihres Profils.
+- Frontend-Komponente: [`supabase-storage/frontend.tsx`](./supabase-storage/frontend.tsx)
+- Cloudflare-Worker (Route `PUT /api/items/:id/image`): [`supabase-storage/worker.ts`](./supabase-storage/worker.ts)
+
+**Ablauf**
+
+1. Der Client prüft Dateityp (`image/*`) und Größe (≤2&nbsp;MB).
+2. Upload direkt in den Bucket `item-images` mittels Supabase-Client.
+3. Der Bucket liefert eine public URL, die zusammen mit Metadaten an den Worker gesendet wird.
+4. Der Worker verifiziert das Zugriffstoken, validiert Dateityp/Größe und speichert die URL in `items.image_url`.
+
+**Konfiguration**
+
+```bash
+SUPABASE_URL=<https://your-project.supabase.co>
+SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
+PUBLIC_SUPABASE_URL=$SUPABASE_URL
+PUBLIC_SUPABASE_ANON_KEY=<anon-key>
+```
+
+Binde den Worker in `wrangler.toml` z.&nbsp;B. so ein:
+
+```toml
+[[routes]]
+pattern = "example.com/api/items/*/image"
+script = "item-image"
+```
+
+## Variante B – Cloudflare R2 + Signierter Upload
+
+- R2-Bucket mit public CDN/Custom-Domain (Basis-URL in `R2_PUBLIC_BASE_URL`).
+- Worker-Route `POST /api/upload-url`: [`r2-signed-upload/worker.ts`](./r2-signed-upload/worker.ts)
+- Frontend-Komponente: [`r2-signed-upload/frontend.tsx`](./r2-signed-upload/frontend.tsx)
+
+**Ablauf**
+
+1. Client prüft Dateityp und Größe wie oben.
+2. Client ruft `POST /api/upload-url` mit Item-ID, Dateigröße und Content-Type auf.
+3. Worker verifiziert das Supabase-Token, erzeugt eine 5&nbsp;Minuten gültige PUT-Signed-URL für R2 und liefert zusätzlich die spätere public URL.
+4. Client lädt die Datei direkt nach R2 hoch.
+5. Client schreibt die public URL in `items.image_url` (hier direkt via Supabase-Client, alternativ über denselben Worker wie in Variante&nbsp;A).
+
+**Konfiguration**
+
+```bash
+SUPABASE_URL=<https://your-project.supabase.co>
+SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
+PUBLIC_SUPABASE_URL=$SUPABASE_URL
+PUBLIC_SUPABASE_ANON_KEY=<anon-key>
+R2_PUBLIC_BASE_URL=<https://cdn.example.com/item-images>
+```
+
+`wrangler.toml` (Auszug):
+
+```toml
+[[routes]]
+pattern = "example.com/api/upload-url"
+script = "item-upload-url"
+
+[[r2_buckets]]
+binding = "ITEM_IMAGES"
+bucket_name = "item-images"
+```
+
+Die Worker geben CORS-Header zurück (`*` für Demonstrationszwecke). Passe die Policy in Produktion an deine Domain an.

--- a/examples/upload/r2-signed-upload/frontend.tsx
+++ b/examples/upload/r2-signed-upload/frontend.tsx
@@ -1,0 +1,122 @@
+import { useState, type ChangeEvent } from 'react';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  import.meta.env.PUBLIC_SUPABASE_URL!,
+  import.meta.env.PUBLIC_SUPABASE_ANON_KEY!
+);
+
+const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MB
+
+interface Props {
+  itemId: string;
+}
+
+interface UploadUrlResponse {
+  uploadUrl: string;
+  publicUrl: string;
+}
+
+export function ItemImageUploaderR2({ itemId }: Props) {
+  const [status, setStatus] = useState('');
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    if (!file.type.startsWith('image/')) {
+      setStatus('Bitte nur Bilddateien auswählen.');
+      event.target.value = '';
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      setStatus('Das Bild darf maximal 2 MB groß sein.');
+      event.target.value = '';
+      return;
+    }
+
+    setStatus('Signierte URL wird angefordert …');
+
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    if (!session) {
+      setStatus('Bitte logge dich zuerst ein.');
+      return;
+    }
+
+    const uploadUrlResponse = await fetch('/api/upload-url', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`,
+      },
+      body: JSON.stringify({
+        itemId,
+        contentType: file.type,
+        size: file.size,
+      }),
+    });
+
+    if (!uploadUrlResponse.ok) {
+      const payload = await uploadUrlResponse.json().catch(() => ({}));
+      console.error(payload);
+      setStatus('Konnte keine Upload-URL erzeugen.');
+      return;
+    }
+
+    const { uploadUrl, publicUrl } = (await uploadUrlResponse.json()) as UploadUrlResponse;
+
+    setStatus('Upload läuft …');
+
+    const putResponse = await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': file.type,
+      },
+      body: file,
+    });
+
+    if (!putResponse.ok) {
+      console.error(await putResponse.text());
+      setStatus('Upload nach R2 fehlgeschlagen.');
+      return;
+    }
+
+    const { error: updateError } = await supabase
+      .from('items')
+      .update({ image_url: publicUrl })
+      .eq('id', itemId)
+      .eq('owner_id', session.user.id)
+      .select('id')
+      .single();
+
+    if (updateError) {
+      console.error(updateError);
+      setStatus('Das Bild konnte nicht gespeichert werden.');
+      return;
+    }
+
+    setStatus('Bild erfolgreich hochgeladen.');
+    event.target.value = '';
+  };
+
+  return (
+    <form className="upload-form">
+      <label className="upload-label">
+        Item-Bild hochladen
+        <input
+          accept="image/png,image/jpeg"
+          type="file"
+          onChange={handleFileChange}
+        />
+      </label>
+      {status && <p className="upload-status">{status}</p>}
+    </form>
+  );
+}

--- a/examples/upload/r2-signed-upload/worker.ts
+++ b/examples/upload/r2-signed-upload/worker.ts
@@ -1,0 +1,101 @@
+import { createClient } from '@supabase/supabase-js';
+import type { R2Bucket } from '@cloudflare/workers-types';
+
+interface Env {
+  SUPABASE_URL: string;
+  SUPABASE_SERVICE_ROLE_KEY: string;
+  ITEM_IMAGES: R2Bucket;
+  R2_PUBLIC_BASE_URL: string;
+}
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'OPTIONS,POST',
+  'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+};
+
+const MAX_FILE_SIZE = 2 * 1024 * 1024;
+const SIGNED_UPLOAD_TTL_SECONDS = 5 * 60;
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders });
+    }
+
+    if (request.method !== 'POST') {
+      return new Response('Method not allowed', { status: 405, headers: corsHeaders });
+    }
+
+    const authorization = request.headers.get('Authorization');
+    const accessToken = authorization?.replace('Bearer ', '').trim();
+
+    if (!accessToken) {
+      return new Response('Unauthorized', { status: 401, headers: corsHeaders });
+    }
+
+    const payload = await request.json().catch(() => null);
+
+    if (
+      !payload ||
+      typeof payload.contentType !== 'string' ||
+      typeof payload.size !== 'number' ||
+      typeof payload.itemId !== 'string'
+    ) {
+      return new Response('Invalid payload', { status: 400, headers: corsHeaders });
+    }
+
+    const { contentType, size, itemId } = payload as {
+      contentType: string;
+      size: number;
+      itemId: string;
+    };
+
+    if (!contentType.startsWith('image/')) {
+      return new Response('Invalid content type', { status: 400, headers: corsHeaders });
+    }
+
+    if (!Number.isFinite(size) || size <= 0 || size > MAX_FILE_SIZE) {
+      return new Response('File too large', { status: 413, headers: corsHeaders });
+    }
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { data: authData, error: authError } = await supabase.auth.getUser(accessToken);
+
+    if (authError || !authData?.user) {
+      return new Response('Unauthorized', { status: 401, headers: corsHeaders });
+    }
+
+    const extension = contentType.split('/')[1]?.toLowerCase() ?? 'bin';
+    const objectKey = `${authData.user.id}/${itemId}/${crypto.randomUUID()}.${extension}`;
+
+    const signedUrl = await env.ITEM_IMAGES.createSignedUrl({
+      key: objectKey,
+      method: 'PUT',
+      expiration: SIGNED_UPLOAD_TTL_SECONDS,
+      headers: {
+        'content-type': contentType,
+        'content-length': size.toString(),
+      },
+    });
+
+    const publicUrl = `${env.R2_PUBLIC_BASE_URL.replace(/\/$/, '')}/${objectKey}`;
+
+    return new Response(
+      JSON.stringify({
+        uploadUrl: signedUrl.toString(),
+        publicUrl,
+      }),
+      {
+        status: 200,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  },
+};

--- a/examples/upload/supabase-storage/frontend.tsx
+++ b/examples/upload/supabase-storage/frontend.tsx
@@ -1,0 +1,106 @@
+import { useState, type ChangeEvent } from 'react';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  import.meta.env.PUBLIC_SUPABASE_URL!,
+  import.meta.env.PUBLIC_SUPABASE_ANON_KEY!
+);
+
+const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MB
+
+interface Props {
+  itemId: string;
+}
+
+export function ItemImageUploader({ itemId }: Props) {
+  const [status, setStatus] = useState<string>('');
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    if (!file.type.startsWith('image/')) {
+      setStatus('Bitte nur Bilddateien auswählen.');
+      event.target.value = '';
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      setStatus('Das Bild darf maximal 2 MB groß sein.');
+      event.target.value = '';
+      return;
+    }
+
+    setStatus('Starte Upload …');
+
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    if (!session) {
+      setStatus('Bitte logge dich zuerst ein.');
+      return;
+    }
+
+    const fileExt = file.name.split('.').pop()?.toLowerCase() ?? 'png';
+    const storagePath = `${session.user.id}/${itemId}/${Date.now()}.${fileExt}`;
+
+    const { error: uploadError } = await supabase.storage
+      .from('item-images')
+      .upload(storagePath, file, {
+        contentType: file.type,
+        upsert: true,
+      });
+
+    if (uploadError) {
+      console.error(uploadError);
+      setStatus('Upload fehlgeschlagen.');
+      return;
+    }
+
+    const { data: publicData } = supabase.storage.from('item-images').getPublicUrl(storagePath);
+    const publicUrl = publicData.publicUrl;
+
+    const response = await fetch(`/api/items/${itemId}/image`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`,
+      },
+      body: JSON.stringify({
+        imageUrl: publicUrl,
+        metadata: {
+          contentType: file.type,
+          size: file.size,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({}));
+      console.error(payload);
+      setStatus('Das Bild konnte nicht gespeichert werden.');
+      return;
+    }
+
+    setStatus('Bild erfolgreich hochgeladen.');
+    event.target.value = '';
+  };
+
+  return (
+    <form className="upload-form">
+      <label className="upload-label">
+        Item-Bild hochladen
+        <input
+          accept="image/png,image/jpeg"
+          type="file"
+          onChange={handleFileChange}
+        />
+      </label>
+      {status && <p className="upload-status">{status}</p>}
+    </form>
+  );
+}

--- a/examples/upload/supabase-storage/worker.ts
+++ b/examples/upload/supabase-storage/worker.ts
@@ -1,0 +1,100 @@
+import { createClient } from '@supabase/supabase-js';
+
+interface Env {
+  SUPABASE_URL: string;
+  SUPABASE_SERVICE_ROLE_KEY: string;
+}
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'OPTIONS,PUT',
+  'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+};
+
+const MAX_FILE_SIZE = 2 * 1024 * 1024;
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders });
+    }
+
+    if (request.method !== 'PUT') {
+      return new Response('Method not allowed', { status: 405, headers: corsHeaders });
+    }
+
+    const authorization = request.headers.get('Authorization');
+    const accessToken = authorization?.replace('Bearer ', '').trim();
+
+    if (!accessToken) {
+      return new Response('Unauthorized', { status: 401, headers: corsHeaders });
+    }
+
+    const url = new URL(request.url);
+    const parts = url.pathname.replace(/^\/+/, '').split('/');
+
+    if (parts.length !== 4 || parts[0] !== 'api' || parts[1] !== 'items' || parts[3] !== 'image') {
+      return new Response('Not found', { status: 404, headers: corsHeaders });
+    }
+
+    const itemId = parts[2];
+
+    const payload = (await request.json().catch(() => null)) as
+      | {
+          imageUrl?: unknown;
+          metadata?: { contentType?: unknown; size?: unknown };
+        }
+      | null;
+
+    if (!payload || typeof payload.imageUrl !== 'string') {
+      return new Response('Missing imageUrl', { status: 400, headers: corsHeaders });
+    }
+
+    const metadata = payload.metadata ?? {};
+    const contentType =
+      typeof metadata.contentType === 'string' ? metadata.contentType : undefined;
+    const size =
+      typeof metadata.size === 'number' ? Number(metadata.size) : Number.NaN;
+
+    if (!contentType || !contentType.startsWith('image/')) {
+      return new Response('Invalid content type', { status: 400, headers: corsHeaders });
+    }
+
+    if (!Number.isFinite(size) || size <= 0 || size > MAX_FILE_SIZE) {
+      return new Response('File too large', { status: 413, headers: corsHeaders });
+    }
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { data: authData, error: authError } = await supabase.auth.getUser(accessToken);
+
+    if (authError || !authData?.user) {
+      return new Response('Unauthorized', { status: 401, headers: corsHeaders });
+    }
+
+    const imageUrl = payload.imageUrl;
+
+    const { error: updateError } = await supabase
+      .from('items')
+      .update({ image_url: imageUrl })
+      .eq('id', itemId)
+      .eq('owner_id', authData.user.id)
+      .select('id')
+      .single();
+
+    if (updateError) {
+      console.error(updateError);
+      return new Response('Could not update item', { status: 400, headers: corsHeaders });
+    }
+
+    return new Response(JSON.stringify({ imageUrl }), {
+      status: 200,
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'application/json',
+      },
+    });
+  },
+};


### PR DESCRIPTION
## Summary
- document minimal Supabase Storage and Cloudflare R2 image upload variants
- add frontend examples that validate files and upload item images
- provide worker samples for storing image URLs and generating signed upload URLs

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c890e553e08324852d28ee87ecf4cc