### PR TITLE
Move Cloudflare functions under /api directory

### DIFF
--- a/functions/api/items.ts
+++ b/functions/api/items.ts
@@ -1,11 +1,11 @@
 import type { PagesFunction } from '@cloudflare/workers-types';
-import { getSupabaseClient, type SupabaseEnv } from '../lib/supabase';
+import { getSupabaseClient, type SupabaseEnv } from '../../lib/supabase';
 import {
   jsonError,
   preflightResponse,
   withCache,
   type CacheEnv,
-} from '../lib/cache';
+} from '../../lib/cache';
 
 interface Item {
   id: string;

--- a/functions/api/items/[id].ts
+++ b/functions/api/items/[id].ts
@@ -1,11 +1,11 @@
 import type { PagesFunction } from '@cloudflare/workers-types';
-import { getSupabaseClient, type SupabaseEnv } from '../../lib/supabase';
+import { getSupabaseClient, type SupabaseEnv } from '../../../lib/supabase';
 import {
   jsonError,
   preflightResponse,
   withCache,
   type CacheEnv,
-} from '../../lib/cache';
+} from '../../../lib/cache';
 
 type Env = SupabaseEnv & CacheEnv;
 

--- a/functions/api/search.ts
+++ b/functions/api/search.ts
@@ -1,11 +1,11 @@
 import type { PagesFunction } from '@cloudflare/workers-types';
-import { getSupabaseClient, type SupabaseEnv } from '../lib/supabase';
+import { getSupabaseClient, type SupabaseEnv } from '../../lib/supabase';
 import {
   jsonError,
   preflightResponse,
   withCache,
   type CacheEnv,
-} from '../lib/cache';
+} from '../../lib/cache';
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 50;


### PR DESCRIPTION
## Summary
- move the items, search, and item-detail functions into the `functions/api` directory so they deploy under `/api/*`
- update relative imports in the moved handlers to account for the new depth

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c89e492f348324a5429dfee562e174