### PR TITLE
Refactor limit parsing into shared helper

### DIFF
--- a/functions/api/items.ts
+++ b/functions/api/items.ts
@@ -6,6 +6,7 @@ import {
   withCache,
   type CacheEnv,
 } from '../../lib/cache';
+import { parseLimit } from '../../lib/request-params';
 
 interface Item {
   id: string;
@@ -20,13 +21,6 @@ type Env = SupabaseEnv & CacheEnv;
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
-
-const parseLimit = (value: string | null): number => {
-  if (!value) return DEFAULT_LIMIT;
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIMIT;
-  return Math.min(Math.floor(parsed), MAX_LIMIT);
-};
 
 interface Cursor {
   releasedAt?: string;
@@ -90,7 +84,11 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
 
   return withCache(request, env, async () => {
     const url = new URL(request.url);
-    const limit = parseLimit(url.searchParams.get('limit'));
+    const limit = parseLimit(
+      url.searchParams.get('limit'),
+      DEFAULT_LIMIT,
+      MAX_LIMIT
+    );
     const cursor = parseCursor(url.searchParams.get('cursor'));
 
     const supabase = getSupabaseClient(env);

--- a/functions/api/search.ts
+++ b/functions/api/search.ts
@@ -6,18 +6,12 @@ import {
   withCache,
   type CacheEnv,
 } from '../../lib/cache';
+import { parseLimit } from '../../lib/request-params';
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 50;
 
 type Env = SupabaseEnv & CacheEnv;
-
-const parseLimit = (value: string | null): number => {
-  if (!value) return DEFAULT_LIMIT;
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIMIT;
-  return Math.min(Math.floor(parsed), MAX_LIMIT);
-};
 
 const escapeForILike = (value: string): string =>
   value.replace(/[%_]/g, (match) => `\\${match}`);
@@ -38,7 +32,11 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
     return jsonError('Query parameter "q" is required', 400);
   }
 
-  const limit = parseLimit(url.searchParams.get('limit'));
+  const limit = parseLimit(
+    url.searchParams.get('limit'),
+    DEFAULT_LIMIT,
+    MAX_LIMIT
+  );
   const typeFilter = url.searchParams.get('type')?.trim() || null;
   const rarityFilter = url.searchParams.get('rarity')?.trim() || null;
 

--- a/lib/request-params.ts
+++ b/lib/request-params.ts
@@ -1,0 +1,51 @@
+const toPositiveInteger = (value: number): number | null => {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  const integer = Math.floor(value);
+  return integer > 0 ? integer : null;
+};
+
+const getFallbackLimit = (
+  defaultLimit: number,
+  maxLimit: number
+): [number, number] => {
+  const normalizedMax = toPositiveInteger(maxLimit) ?? 1;
+  const normalizedDefault = toPositiveInteger(defaultLimit);
+  const fallback = normalizedDefault
+    ? Math.min(normalizedDefault, normalizedMax)
+    : normalizedMax;
+
+  return [fallback, normalizedMax];
+};
+
+/**
+ * Parses a numeric limit query parameter, ensuring that the result is a positive
+ * integer that does not exceed the provided maximum. Invalid values fall back
+ * to the provided default limit.
+ */
+export const parseLimit = (
+  value: string | null,
+  defaultLimit: number,
+  maxLimit: number
+): number => {
+  const [fallback, normalizedMax] = getFallbackLimit(defaultLimit, maxLimit);
+
+  if (!value) {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+
+  const parsed = Number(trimmed);
+  const positive = toPositiveInteger(parsed);
+  if (!positive) {
+    return fallback;
+  }
+
+  return Math.min(positive, normalizedMax);
+};


### PR DESCRIPTION
## Summary
- add a reusable `parseLimit` helper for request parameters
- update the items and search functions to use the shared limit parser

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c89f938a948324b39c45825090fc9c