### PR TITLE
Sanitize Supabase placeholders in wrangler config

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,8 +3,8 @@ compatibility_date = "2023-12-01"
 pages_build_output_dir = "./public"
 
 [vars]
-PUBLIC_SUPABASE_URL = "https://taejvzqmlswbgsknthxz.supabase.co"
-PUBLIC_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRhZWp2enFtbHN3Ymdza250aHh6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTczNTE3NjIsImV4cCI6MjA3MjkyNzc2Mn0.nFWly256mUiFAvAEWdvLA9n_DaNXOnV3MtMLXmHIKGc"
+PUBLIC_SUPABASE_URL = "https://your-project.supabase.co"
+PUBLIC_SUPABASE_ANON_KEY = "public-anon-key"
 API_BASE = "https://api.example.com"
 SUPABASE_URL = "{{ secret:SUPABASE_URL }}"
 SUPABASE_ANON_KEY = "{{ secret:SUPABASE_ANON_KEY }}"


### PR DESCRIPTION
## Summary
- replace the hardcoded Supabase URL and anon key in wrangler.toml with generic placeholders
- confirm that sensitive Supabase values continue to be sourced via Wrangler secrets rather than committed configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8a5c0346c83249939773d9fb38dc6