### PR TITLE
Adjust add item form fields

### DIFF
--- a/public/db/app/create-item.js
+++ b/public/db/app/create-item.js
@@ -36,15 +36,6 @@ const setFormBusy = (busy) => {
   }
 };
 
-const toIsoString = (value) => {
-  if (typeof value !== 'string') return '';
-  const trimmed = value.trim();
-  if (!trimmed) return '';
-  const date = new Date(trimmed);
-  if (Number.isNaN(date.getTime())) return '';
-  return date.toISOString();
-};
-
 const collectFormData = () => {
   const form = elements.addItemForm;
   if (!form) {
@@ -55,7 +46,6 @@ const collectFormData = () => {
   const name = typeof data.get('name') === 'string' ? data.get('name').trim() : '';
   const type = typeof data.get('type') === 'string' ? data.get('type').trim() : '';
   const rarity = typeof data.get('rarity') === 'string' ? data.get('rarity').trim() : '';
-  const releasedAtRaw = typeof data.get('released_at') === 'string' ? data.get('released_at').trim() : '';
 
   if (!name) {
     throw new Error('Bitte einen Namen angeben.');
@@ -67,23 +57,18 @@ const collectFormData = () => {
     throw new Error('Bitte eine Seltenheit auswählen.');
   }
 
-  const releasedAt = toIsoString(releasedAtRaw);
-  if (!releasedAt) {
-    throw new Error('Bitte ein gültiges Veröffentlichungsdatum angeben.');
-  }
-
   const payload = {
     name,
     type,
     rarity,
-    released_at: releasedAt
+    released_at: new Date().toISOString()
   };
 
   const starsValue = typeof data.get('stars') === 'string' ? data.get('stars').trim() : '';
   if (starsValue) {
     const stars = Number(starsValue);
-    if (!Number.isFinite(stars) || stars < 0) {
-      throw new Error('Bitte eine gültige Sternanzahl angeben.');
+    if (!Number.isFinite(stars) || stars < 0 || stars > 3) {
+      throw new Error('Bitte eine gültige Sternanzahl zwischen 0 und 3 angeben.');
     }
     payload.stars = stars;
   }

--- a/public/db/app/elements.js
+++ b/public/db/app/elements.js
@@ -12,7 +12,6 @@ export const elements = {
   addItemName: document.getElementById('addItemName'),
   addItemType: document.getElementById('addItemType'),
   addItemRarity: document.getElementById('addItemRarity'),
-  addItemReleasedAt: document.getElementById('addItemReleasedAt'),
   addItemStars: document.getElementById('addItemStars'),
   addItemImageUrl: document.getElementById('addItemImageUrl'),
   addItemDescription: document.getElementById('addItemDescription'),

--- a/public/db/index.html
+++ b/public/db/index.html
@@ -148,12 +148,8 @@
             </select>
           </div>
           <div class="modal__field">
-            <label for="addItemReleasedAt">Veröffentlicht am</label>
-            <input id="addItemReleasedAt" name="released_at" type="datetime-local" required />
-          </div>
-          <div class="modal__field">
             <label for="addItemStars">Sterne (optional)</label>
-            <input id="addItemStars" name="stars" type="number" min="0" step="1" />
+            <input id="addItemStars" name="stars" type="number" min="0" max="3" step="1" />
           </div>
           <div class="modal__field">
             <label for="addItemImageUrl">Bild-URL (optional)</label>


### PR DESCRIPTION
## Summary
- remove the release date input from the add item modal and associated element lookup
- restrict the optional star field to a maximum of three and validate accordingly while auto-populating the release timestamp

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c921aa3a988324bb59390b9e46dbcc