### PR TITLE
Add POST handler for items API and extend tests

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -20,12 +20,14 @@ export interface CachedComputeResult {
 function applyCorsAndCachingHeaders(headers: Headers): Headers {
   headers.set('Content-Type', 'application/json; charset=utf-8');
   headers.set('Access-Control-Allow-Origin', '*');
-  headers.set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
   headers.set(
     'Access-Control-Allow-Headers',
     'Content-Type, Authorization, X-Requested-With, apikey'
   );
-  headers.set('Cache-Control', `public, max-age=${BROWSER_CACHE_TTL_SECONDS}`);
+  if (!headers.has('Cache-Control')) {
+    headers.set('Cache-Control', `public, max-age=${BROWSER_CACHE_TTL_SECONDS}`);
+  }
   return headers;
 }
 

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -7,7 +7,10 @@ test('search API returns CORS headers for OPTIONS requests', async () => {
   const response = await onRequest({ request, env: {} } as any);
 
   assert.equal(response.status, 204);
-  assert.equal(response.headers.get('Access-Control-Allow-Methods'), 'GET, OPTIONS');
+  assert.equal(
+    response.headers.get('Access-Control-Allow-Methods'),
+    'GET, POST, OPTIONS'
+  );
   assert.equal(response.headers.get('Access-Control-Allow-Origin'), '*');
 });
 


### PR DESCRIPTION
## Summary
- extend the items API with a POST handler that validates input, enforces bearer-token auth, inserts the item via Supabase, and returns the created record
- update shared CORS headers to allow POST requests and ensure creation responses bypass caching
- expand the test suite and Supabase stub to cover POST flows and expect the new headers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c924d794888324bc76c083ed9bf4b4