### PR TITLE
Update rarity tiers to new German labels

### DIFF
--- a/public/db/app/filters.js
+++ b/public/db/app/filters.js
@@ -1,19 +1,19 @@
 import { state } from './state.js';
 import { getItemTypeKey } from './item-types.js';
-import { normalizeFilterValue } from './utils.js';
+import { getRarityKey } from './utils.js';
 
 export const filtersApplied = () =>
-  Boolean(getItemTypeKey(state.filters.type) || normalizeFilterValue(state.filters.rarity));
+  Boolean(getItemTypeKey(state.filters.type) || getRarityKey(state.filters.rarity));
 
 export const applyFilters = (items) => {
   const typeFilter = getItemTypeKey(state.filters.type);
-  const rarityFilter = normalizeFilterValue(state.filters.rarity);
+  const rarityFilter = getRarityKey(state.filters.rarity);
 
   if (!typeFilter && !rarityFilter) return items;
 
   return items.filter((item) => {
     const itemType = getItemTypeKey(item?.type);
-    const itemRarity = normalizeFilterValue(item?.rarity);
+    const itemRarity = getRarityKey(item?.rarity);
     const matchesType = !typeFilter || itemType === typeFilter;
     const matchesRarity = !rarityFilter || itemRarity === rarityFilter;
     return matchesType && matchesRarity;

--- a/public/db/app/render.js
+++ b/public/db/app/render.js
@@ -1,7 +1,7 @@
 import { elements } from './elements.js';
 import { applyFilters, filtersApplied } from './filters.js';
 import { state } from './state.js';
-import { formatLabel, getInitial, getStarLevel, normalizeFilterValue, renderStars } from './utils.js';
+import { formatLabel, getInitial, getRarityKey, getStarLevel, renderStars } from './utils.js';
 import { openDetail } from './detail.js';
 
 export const updateStatusMessage = () => {
@@ -104,8 +104,12 @@ const createCard = (item) => {
 
   const rarity = document.createElement('span');
   rarity.className = 'rarity-badge';
-  const rarityValue = normalizeFilterValue(item?.rarity);
-  rarity.dataset.rarity = rarityValue;
+  const rarityValue = getRarityKey(item?.rarity);
+  if (rarityValue) {
+    rarity.dataset.rarity = rarityValue;
+  } else {
+    delete rarity.dataset.rarity;
+  }
   rarity.textContent = formatLabel(item?.rarity);
 
   const type = document.createElement('span');

--- a/public/db/index.html
+++ b/public/db/index.html
@@ -65,12 +65,12 @@
             <span class="filter__label">Seltenheit</span>
             <select id="rarityFilter" name="rarity">
               <option value="">Alle Seltenheiten</option>
-              <option value="common">Common</option>
-              <option value="uncommon">Uncommon</option>
-              <option value="rare">Rare</option>
-              <option value="epic">Epic</option>
-              <option value="legendary">Legendary</option>
-              <option value="mythic">Mythic</option>
+              <option value="selten">Selten</option>
+              <option value="episch">Episch</option>
+              <option value="unbezahlbar">Unbezahlbar</option>
+              <option value="legendaer">Legendär</option>
+              <option value="jackpot">Jackpot</option>
+              <option value="mega-jackpot">Mega Jackpot</option>
             </select>
           </label>
         </form>
@@ -139,12 +139,12 @@
             <label for="addItemRarity">Seltenheit</label>
             <select id="addItemRarity" name="rarity" required>
               <option value="">Bitte auswählen</option>
-              <option value="common">Common</option>
-              <option value="uncommon">Uncommon</option>
-              <option value="rare">Rare</option>
-              <option value="epic">Epic</option>
-              <option value="legendary">Legendary</option>
-              <option value="mythic">Mythic</option>
+              <option value="selten">Selten</option>
+              <option value="episch">Episch</option>
+              <option value="unbezahlbar">Unbezahlbar</option>
+              <option value="legendaer">Legendär</option>
+              <option value="jackpot">Jackpot</option>
+              <option value="mega-jackpot">Mega Jackpot</option>
             </select>
           </div>
           <div class="modal__field">

--- a/public/db/style.css
+++ b/public/db/style.css
@@ -340,34 +340,34 @@ select {
   color: rgba(191, 219, 254, 0.88);
 }
 
-.rarity-badge[data-rarity='common'] {
-  background: rgba(148, 163, 184, 0.18);
-  color: rgba(226, 232, 240, 0.75);
-}
-
-.rarity-badge[data-rarity='uncommon'] {
-  background: rgba(34, 197, 94, 0.16);
-  color: rgba(187, 247, 208, 0.9);
-}
-
-.rarity-badge[data-rarity='rare'] {
+.rarity-badge[data-rarity='selten'] {
   background: rgba(59, 130, 246, 0.16);
   color: rgba(191, 219, 254, 0.88);
 }
 
-.rarity-badge[data-rarity='epic'] {
+.rarity-badge[data-rarity='episch'] {
   background: rgba(129, 140, 248, 0.18);
   color: rgba(199, 210, 254, 0.95);
 }
 
-.rarity-badge[data-rarity='legendary'] {
+.rarity-badge[data-rarity='unbezahlbar'] {
+  background: rgba(13, 148, 136, 0.18);
+  color: rgba(167, 243, 208, 0.92);
+}
+
+.rarity-badge[data-rarity='legendaer'] {
   background: rgba(245, 158, 11, 0.22);
   color: rgba(253, 230, 138, 0.95);
 }
 
-.rarity-badge[data-rarity='mythic'] {
+.rarity-badge[data-rarity='jackpot'] {
   background: rgba(236, 72, 153, 0.22);
   color: rgba(251, 207, 232, 0.92);
+}
+
+.rarity-badge[data-rarity='mega-jackpot'] {
+  background: rgba(250, 204, 21, 0.28);
+  color: rgba(254, 243, 199, 0.95);
 }
 
 .item-card__type {

--- a/tests/items.test.ts
+++ b/tests/items.test.ts
@@ -132,21 +132,21 @@ test('items API returns items and a next cursor from Supabase results', async ()
       id: 'item-3',
       name: 'Item Three',
       type: 'weapon',
-      rarity: 'legendary',
+      rarity: 'mega-jackpot',
       released_at: '2023-03-10T00:00:00.000Z',
     },
     {
       id: 'item-2',
       name: 'Item Two',
       type: 'weapon',
-      rarity: 'rare',
+      rarity: 'legendaer',
       released_at: '2023-03-09T00:00:00.000Z',
     },
     {
       id: 'item-1',
       name: 'Item One',
       type: 'weapon',
-      rarity: 'common',
+      rarity: 'selten',
       released_at: '2023-03-08T00:00:00.000Z',
     },
   ];
@@ -177,7 +177,7 @@ test('items API rejects POST requests without a valid bearer token', async () =>
     body: JSON.stringify({
       name: 'Unauthorized Item',
       type: 'weapon',
-      rarity: 'rare',
+      rarity: 'jackpot',
       released_at: '2024-01-01T00:00:00Z',
     }),
   });
@@ -201,7 +201,7 @@ test('items API validates POST request payloads', async () => {
     body: JSON.stringify({
       name: '  ',
       type: 'weapon',
-      rarity: 'rare',
+      rarity: 'jackpot',
     }),
   });
 
@@ -219,7 +219,7 @@ test('items API inserts new items via POST requests', async () => {
     id: 'item-123',
     name: 'Test Item',
     type: 'weapon',
-    rarity: 'rare',
+    rarity: 'jackpot',
     released_at: '2024-01-01T00:00:00.000Z',
   };
 
@@ -234,7 +234,7 @@ test('items API inserts new items via POST requests', async () => {
     body: JSON.stringify({
       name: '  Test Item  ',
       type: 'weapon',
-      rarity: 'rare',
+      rarity: 'jackpot',
       released_at: '2024-01-01T00:00:00Z',
     }),
   });
@@ -257,7 +257,7 @@ test('items API inserts new items via POST requests', async () => {
     {
       name: 'Test Item',
       type: 'weapon',
-      rarity: 'rare',
+      rarity: 'jackpot',
       released_at: '2024-01-01T00:00:00.000Z',
     },
   ]);

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -59,7 +59,7 @@ test('search API rejects unsupported HTTP methods', async () => {
 });
 
 test('search API returns a helpful error when Supabase configuration is missing', async () => {
-  const request = createRequest('/api/search?q=legendary', { method: 'GET' });
+  const request = createRequest('/api/search?q=jackpot', { method: 'GET' });
   const response = await onRequest({ request, env: {} } as any);
   const body = await response.json();
 
@@ -71,7 +71,7 @@ test('search API falls back to the default limit when the parameter is invalid',
   const { env, cacheKey } = createEnv();
   supabaseStub.__queueResponse(cacheKey, { data: [] });
 
-  const request = createRequest('/api/search?q=legendary&limit=not-a-number');
+  const request = createRequest('/api/search?q=jackpot&limit=not-a-number');
   const response = await onRequest({ request, env } as any);
   const body = await response.json();
 
@@ -100,7 +100,7 @@ test('search API handles Supabase errors gracefully', async () => {
     },
   });
 
-  const request = createRequest('/api/search?q=legendary&type=weapon&rarity=rare');
+  const request = createRequest('/api/search?q=jackpot&type=weapon&rarity=mega-jackpot');
   const response = await onRequest({ request, env } as any);
   const body = await response.json();
 
@@ -117,14 +117,14 @@ test('search API returns search results from Supabase', async () => {
       id: 'item-1',
       name: 'Sword of Testing',
       type: 'weapon',
-      rarity: 'rare',
+      rarity: 'selten',
       released_at: '2023-01-01T00:00:00.000Z',
     },
     {
       id: 'item-2',
       name: 'Axe of Assertions',
       type: 'weapon',
-      rarity: 'legendary',
+      rarity: 'legendaer',
       released_at: '2023-01-02T00:00:00.000Z',
     },
   ];


### PR DESCRIPTION
## Summary
- replace the database UI rarity options with the new Selten→Mega Jackpot labels and colors
- add rarity normalization helpers and use them when rendering badges and applying filters
- update API tests to cover the new rarity slugs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c93875bb0083248396eb82ab822f0d