### PR TITLE
Fix discordId declaration in auth module

### DIFF
--- a/public/db/app/auth.js
+++ b/public/db/app/auth.js
@@ -88,7 +88,7 @@ const mapUserToProfile = (user) => {
     typeof metadata.avatar_url === 'string' && metadata.avatar_url.trim()
       ? metadata.avatar_url.trim()
       : null;
-  let discordId: string | null = null;
+  let discordId = null;
   const identities = Array.isArray(user.identities) ? user.identities : [];
   for (const identity of identities) {
     if (identity?.provider === 'discord') {


### PR DESCRIPTION
## Summary
- remove the TypeScript type annotation from the discordId initialization so the file stays valid JavaScript

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c94df1d7ac832483361da4b7cdc170