### PR TITLE
Switch Supabase imports to CDN URL

### DIFF
--- a/examples/upload/r2-signed-upload/frontend.tsx
+++ b/examples/upload/r2-signed-upload/frontend.tsx
@@ -1,5 +1,5 @@
 import { useState, type ChangeEvent } from 'react';
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 
 const supabase = createClient(
   import.meta.env.PUBLIC_SUPABASE_URL!,

--- a/examples/upload/r2-signed-upload/worker.ts
+++ b/examples/upload/r2-signed-upload/worker.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 import type { R2Bucket } from '@cloudflare/workers-types';
 
 interface Env {

--- a/examples/upload/supabase-storage/frontend.tsx
+++ b/examples/upload/supabase-storage/frontend.tsx
@@ -1,5 +1,5 @@
 import { useState, type ChangeEvent } from 'react';
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 
 const supabase = createClient(
   import.meta.env.PUBLIC_SUPABASE_URL!,

--- a/examples/upload/supabase-storage/worker.ts
+++ b/examples/upload/supabase-storage/worker.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 
 interface Env {
   SUPABASE_URL: string;

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,4 +1,4 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 
 export interface SupabaseEnv {
   SUPABASE_URL: string;

--- a/public/db/app/auth.js
+++ b/public/db/app/auth.js
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 import { state } from './state.js';
 import { render } from './render.js';
 

--- a/tests/items.test.ts
+++ b/tests/items.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
-import assert from 'node:assert/strict';
-import * as supabase from '@supabase/supabase-js';
+import * as assert from 'node:assert/strict';
+import * as supabase from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 import { onRequest } from '../functions/api/items';
 
 const supabaseStub: any = supabase;
@@ -235,7 +235,8 @@ test('items API validates POST request payloads', async () => {
   const body = await response.json();
 
   assert.equal(response.status, 400);
-  assert.match(body.error, /Invalid request body/);
+  const errorMessage = typeof body.error === 'string' ? body.error : '';
+  assert.equal(/Invalid request body/.test(errorMessage), true);
   assert.equal(supabaseStub.__getLastAuthToken(cacheKey), accessToken);
 });
 
@@ -283,7 +284,7 @@ test('items API inserts new items via POST requests', async () => {
   }
 
   const insertStep = lastQuery.steps.find((step: any) => step[0] === 'insert');
-  assert.ok(insertStep, 'Expected insert step to be recorded');
+  assert.equal(insertStep !== undefined, true, 'Expected insert step to be recorded');
   assert.deepEqual(insertStep[1], [
     {
       name: 'Test Item',

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
-import assert from 'node:assert/strict';
+import * as assert from 'node:assert/strict';
 import { onRequest } from '../functions/api/search';
-import * as supabase from '@supabase/supabase-js';
+import * as supabase from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 
 const supabaseStub: any = supabase;
 

--- a/tests/test-setup.cjs
+++ b/tests/test-setup.cjs
@@ -2,9 +2,10 @@ const Module = require('module');
 const path = require('node:path');
 
 const originalLoad = Module._load;
+const SUPABASE_MODULE = 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 
 Module._load = function patchedLoad(request, parent, isMain) {
-  if (request === '@supabase/supabase-js') {
+  if (request === SUPABASE_MODULE || request === '@supabase/supabase-js') {
     return require(path.join(__dirname, 'stubs', 'supabase-js.js'));
   }
 

--- a/types/supabase-js.d.ts
+++ b/types/supabase-js.d.ts
@@ -32,3 +32,8 @@ declare module '@supabase/supabase-js' {
     options?: Record<string, unknown>
   ): SupabaseClient;
 }
+
+declare module 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm' {
+  export type { QueryResult, PostgrestQueryBuilder, SupabaseAuthClient, SupabaseClient } from '@supabase/supabase-js';
+  export { createClient } from '@supabase/supabase-js';
+}


### PR DESCRIPTION
## Summary
- use the CDN-based ESM import for the Supabase client across the app code, shared library, examples, and tests
- update the test harness and assertions so they work with the CDN Supabase import
- extend the Supabase type declarations to cover the CDN module alias

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c95082d79883248adb42e16e3e77eb