### PR TITLE
Add import map for Supabase CDN

### DIFF
--- a/public/db/index.html
+++ b/public/db/index.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>OP Item Datenbank</title>
     <link rel="stylesheet" href="./style.css" />
+    <script type="importmap">
+      {
+        "imports": {
+          "@supabase/supabase-js": "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"
+        }
+      }
+    </script>
   </head>
   <body>
     <header class="page-header">


### PR DESCRIPTION
## Summary
- add an import map to the DB index page so the Supabase module resolves to the CDN build when served from a simple web server

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c963c4713c832490c24fb8026c594c