### PR TITLE
Fix Supabase URL domain in Wrangler configuration

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@ compatibility_date = "2023-12-01"
 pages_build_output_dir = "./public/db/"
 
 [vars]
-PUBLIC_SUPABASE_URL = "https://taejvzqmlswbgsknthxz.supabase.com"
+PUBLIC_SUPABASE_URL = "https://taejvzqmlswbgsknthxz.supabase.co"
 PUBLIC_SUPABASE_ANON_KEY = "{{ env:PUBLIC_SUPABASE_ANON_KEY }}"
 
 API_BASE = "https://db-website-24f.pages.dev"


### PR DESCRIPTION
## Summary
- update the PUBLIC_SUPABASE_URL in wrangler.toml to use the correct supabase.co domain

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c976ac53f08324bc9d31facf367a99