### PR TITLE
Disable Supabase session persistence in auth client

### DIFF
--- a/public/db/app/auth.js
+++ b/public/db/app/auth.js
@@ -5,6 +5,12 @@ import { render } from './render.js';
 let configPromise = null;
 let clientPromise = null;
 
+const noopAuthStorage = {
+  getItem: async () => null,
+  setItem: async () => {},
+  removeItem: async () => {},
+};
+
 const loadConfig = async () => {
   if (!configPromise) {
     configPromise = fetch('/api/auth/config', {
@@ -50,7 +56,12 @@ const loadConfig = async () => {
 const getClient = async () => {
   if (!clientPromise) {
     clientPromise = loadConfig().then(({ supabaseUrl, supabaseAnonKey }) =>
-      createClient(supabaseUrl, supabaseAnonKey)
+      createClient(supabaseUrl, supabaseAnonKey, {
+        auth: {
+          persistSession: false,
+          storage: noopAuthStorage,
+        },
+      })
     );
   }
   return clientPromise;


### PR DESCRIPTION
## Summary
- pass auth options when creating the Supabase client to disable session persistence
- use a no-op storage adapter so Supabase stops touching local storage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9a1161e5883248b793f0c40bbed47