### PR TITLE
Enable Supabase session persistence

### DIFF
--- a/public/db/app/auth.js
+++ b/public/db/app/auth.js
@@ -5,12 +5,6 @@ import { render } from './render.js';
 let configPromise = null;
 let clientPromise = null;
 
-const noopAuthStorage = {
-  getItem: async () => null,
-  setItem: async () => {},
-  removeItem: async () => {},
-};
-
 const loadConfig = async () => {
   if (!configPromise) {
     configPromise = fetch('/api/auth/config', {
@@ -58,8 +52,7 @@ const getClient = async () => {
     clientPromise = loadConfig().then(({ supabaseUrl, supabaseAnonKey }) =>
       createClient(supabaseUrl, supabaseAnonKey, {
         auth: {
-          persistSession: false,
-          storage: noopAuthStorage,
+          persistSession: true,
         },
       })
     );


### PR DESCRIPTION
## Summary
- re-enable Supabase auth session persistence by using the default browser storage and turning on session persistence

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9a80b6d88832480a15e1af777ff2b