### PR TITLE
Remove Supabase auth fragment from URL after login

### DIFF
--- a/public/db/app/auth.js
+++ b/public/db/app/auth.js
@@ -4,10 +4,21 @@ import { render } from './render.js';
 
 let configPromise = null;
 let clientPromise = null;
+let hasStrippedAuthHash = false;
 
 const AUTH_COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 Tage
 const LOGGED_IN_COOKIE_NAME = 'db_discord_logged_in';
 const DISCORD_ID_COOKIE_NAME = 'db_discord_id';
+
+const AUTH_HASH_SENSITIVE_KEYS = [
+  'access_token',
+  'refresh_token',
+  'provider_token',
+  'provider_refresh_token',
+  'expires_at',
+  'expires_in',
+  'token_type',
+];
 
 const isSecureCookieContext = () => {
   if (typeof window === 'undefined') {
@@ -209,6 +220,50 @@ const applyAuthState = (updates) => {
   render();
 };
 
+const stripAuthHashFromLocation = () => {
+  if (hasStrippedAuthHash) {
+    return;
+  }
+  hasStrippedAuthHash = true;
+
+  if (typeof window === 'undefined' || !window.location) {
+    return;
+  }
+
+  const rawHash = window.location.hash;
+  if (typeof rawHash !== 'string' || rawHash.length <= 1) {
+    return;
+  }
+
+  const trimmedHash = rawHash.startsWith('#') ? rawHash.slice(1) : rawHash;
+  let containsSensitiveAuthData = false;
+
+  try {
+    const params = new URLSearchParams(trimmedHash);
+    for (const key of AUTH_HASH_SENSITIVE_KEYS) {
+      if (params.has(key)) {
+        containsSensitiveAuthData = true;
+        break;
+      }
+    }
+  } catch (error) {
+    const lowerCasedHash = trimmedHash.toLowerCase();
+    containsSensitiveAuthData =
+      lowerCasedHash.includes('access_token=') ||
+      lowerCasedHash.includes('refresh_token=') ||
+      lowerCasedHash.includes('provider_token=');
+  }
+
+  if (!containsSensitiveAuthData) {
+    return;
+  }
+
+  if (typeof window.history?.replaceState === 'function') {
+    const newUrl = `${window.location.pathname}${window.location.search}`;
+    window.history.replaceState(window.history.state, document.title, newUrl);
+  }
+};
+
 const syncProfileWithServer = async (session, profile) => {
   const accessToken =
     typeof session?.access_token === 'string' && session.access_token.trim()
@@ -367,6 +422,8 @@ export const initializeAuth = async () => {
       error: message,
       menuOpen: false,
     });
+  } finally {
+    stripAuthHashFromLocation();
   }
 };
 


### PR DESCRIPTION
## Summary
- add detection of Supabase OAuth fragments so they can be stripped from the location bar
- invoke the fragment cleanup after auth initialization completes to hide access tokens from the URL

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9b2c49dac83249a3a6684101eddfc