### PR TITLE
Configure Supabase auth client for PKCE flow

### DIFF
--- a/public/db/app/auth.js
+++ b/public/db/app/auth.js
@@ -181,6 +181,8 @@ const getClient = async () => {
       createClient(supabaseUrl, supabaseAnonKey, {
         auth: {
           persistSession: true,
+          flowType: 'pkce',
+          detectSessionInUrl: false,
         },
       })
     );


### PR DESCRIPTION
## Summary
- configure the Supabase client to use the PKCE auth flow while keeping manual session detection disabled so our URL cleanup still applies

## Testing
- not run (manual Discord login flow required)


------
https://chatgpt.com/codex/tasks/task_e_68c9d3b4929483249e83f524c903b159