### PR TITLE
chore: harden API response headers

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -25,6 +25,13 @@ function applyCorsAndCachingHeaders(headers: Headers): Headers {
     'Access-Control-Allow-Headers',
     'Content-Type, Authorization, X-Requested-With, apikey'
   );
+  headers.set('X-Content-Type-Options', 'nosniff');
+  headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  headers.set('Permissions-Policy', 'camera=(), geolocation=(), microphone=()');
+  headers.set('Cross-Origin-Opener-Policy', 'same-origin');
+  headers.set('Cross-Origin-Resource-Policy', 'cross-origin');
+  headers.append('Vary', 'Origin');
+  headers.append('Vary', 'Authorization');
   if (!headers.has('Cache-Control')) {
     headers.set('Cache-Control', `public, max-age=${BROWSER_CACHE_TTL_SECONDS}`);
   }


### PR DESCRIPTION
## Summary
- add baseline security headers to the shared response header helper
- ensure cacheable responses vary on Origin and Authorization to prevent leakage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf5acf10483249a4c81293452dc21